### PR TITLE
Try resolve commit from run first 

### DIFF
--- a/src/main/java/io/jenkins/plugins/checks/github/GitHubSCMFacade.java
+++ b/src/main/java/io/jenkins/plugins/checks/github/GitHubSCMFacade.java
@@ -3,9 +3,11 @@ package io.jenkins.plugins.checks.github;
 import com.cloudbees.plugins.credentials.CredentialsMatchers;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 import hudson.model.Job;
+import hudson.model.Run;
 import hudson.security.ACL;
 import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMRevision;
+import jenkins.scm.api.SCMRevisionAction;
 import jenkins.scm.api.SCMSource;
 import org.jenkinsci.plugins.github_branch_source.GitHubAppCredentials;
 import org.jenkinsci.plugins.github_branch_source.GitHubSCMSource;
@@ -61,7 +63,7 @@ public class GitHubSCMFacade {
     }
 
     /**
-     * Fetch the current {@link SCMRevision} used by the {@code head} of the {@code source}.
+     * Fetch the current {@link SCMRevision} of the {@code source} and {@code head} remotely from GitHub.
      *
      * @param source
      *         the GitHub repository
@@ -77,5 +79,19 @@ public class GitHubSCMFacade {
             throw new IllegalStateException(String.format("Could not fetch revision from repository: %s and branch: %s",
                     source.getRepoOwner() + "/" + source.getRepository(), head.getName()), e);
         }
+    }
+
+    /**
+     * Find the current {@link SCMRevision} of the {@code source} and {@code run} locally through
+     * {@link jenkins.scm.api.SCMRevisionAction}.
+     *
+     * @param source
+     *         the GitHub repository
+     * @param run
+     *         the Jenkins run
+     * @return the found revision or empty
+     */
+    public Optional<SCMRevision> findRevision(final GitHubSCMSource source, final Run<?, ?> run) {
+        return Optional.ofNullable(SCMRevisionAction.getRevision(source, run));
     }
 }

--- a/src/test/java/io/jenkins/plugins/checks/github/GitHubChecksContextTest.java
+++ b/src/test/java/io/jenkins/plugins/checks/github/GitHubChecksContextTest.java
@@ -20,6 +20,41 @@ import static org.mockito.Mockito.when;
 
 class GitHubChecksContextTest {
     @Test
+    void shouldGetHeadShaWhenResolveRevisionFromRun() {
+        Job job = mock(Job.class);
+        Run run = mock(Run.class);
+        PullRequestSCMRevision revision = mock(PullRequestSCMRevision.class);
+        GitHubSCMSource source = mock(GitHubSCMSource.class);
+        GitHubSCMFacade scmFacade = mock(GitHubSCMFacade.class);
+
+        when(run.getParent()).thenReturn(job);
+        when(scmFacade.findGitHubSCMSource(job)).thenReturn(Optional.of(source));
+        when(scmFacade.findRevision(source, run)).thenReturn(Optional.of(revision));
+        when(revision.getPullHash()).thenReturn("a1b2c3");
+
+        assertThat(new GitHubChecksContext(run, scmFacade, null)
+                .getHeadSha())
+                .isEqualTo("a1b2c3");
+    }
+
+    @Test
+    void shouldGetHeadShaWhenResolveRevisionFromHead() {
+        Job job = mock(Job.class);
+        Run run = mock(Run.class);
+        SCMHead head = mock(SCMHead.class);
+        PullRequestSCMRevision revision = mock(PullRequestSCMRevision.class);
+        GitHubSCMSource source = mock(GitHubSCMSource.class);
+        GitHubSCMFacade scmFacade = createGitHubSCMFacadeWithRevision(job, source, head, revision);
+
+        when(run.getParent()).thenReturn(job);
+        when(revision.getPullHash()).thenReturn("a1b2c3");
+
+        assertThat(new GitHubChecksContext(run, scmFacade, null)
+                .getHeadSha())
+                .isEqualTo("a1b2c3");
+    }
+
+    @Test
     void shouldGetHeadShaFromMasterBranch() {
         Job job = mock(Job.class);
         SCMHead head = mock(SCMHead.class);


### PR DESCRIPTION
- [x] Resolve commit from run
- [x] Change the [BuildStatusChecksPublisher](https://github.com/jenkinsci/checks-api-plugin/blob/master/src/main/java/io/jenkins/plugins/checks/BuildStatusChecksPublisher.java] to listen to `checkout` instead of `onStarted` since `checkout` is just after `onStarted` and commit is available in run after `checkout`