### PR TITLE
Validate GitHub scm source

### DIFF
--- a/src/main/java/io/jenkins/plugins/checks/github/GitHubChecksContext.java
+++ b/src/main/java/io/jenkins/plugins/checks/github/GitHubChecksContext.java
@@ -1,16 +1,12 @@
 package io.jenkins.plugins.checks.github;
 
-import java.util.Optional;
-
 import edu.hm.hafner.util.FilteredLog;
-import org.apache.commons.lang3.StringUtils;
-
 import edu.umd.cs.findbugs.annotations.CheckForNull;
-
-import org.jenkinsci.plugins.github_branch_source.GitHubAppCredentials;
 import hudson.model.Job;
+import org.apache.commons.lang3.StringUtils;
+import org.jenkinsci.plugins.github_branch_source.GitHubAppCredentials;
 
-import io.jenkins.plugins.util.PluginLogger;
+import java.util.Optional;
 
 /**
  * Base class for a context that publishes GitHub checks.
@@ -29,7 +25,7 @@ abstract class GitHubChecksContext {
     /**
      * Returns the commit sha of the run.
      *
-     * @return the commit sha of the run or null
+     * @return the commit sha of the run
      */
     public abstract String getHeadSha();
 
@@ -50,21 +46,17 @@ abstract class GitHubChecksContext {
      */
     public abstract boolean isValid(FilteredLog logger);
 
-    @Nullable
+    @CheckForNull
     protected abstract String getCredentialsId();
 
     /**
      * Returns the credentials to access the remote GitHub repository.
      *
-     * @return the credentials or null
+     * @return the credentials
      */
     public GitHubAppCredentials getCredentials() {
-        String credentialsId = getCredentialsId();
-        return getGitHubAppCredentials(credentialsId);
+        return getGitHubAppCredentials(StringUtils.defaultIfEmpty(getCredentialsId(), ""));
     }
-
-    @CheckForNull
-    protected abstract String getCredentialsId();
 
     /**
      * Returns the URL of the run's summary page, e.g. https://ci.jenkins.io/job/Core/job/jenkins/job/master/2000/.
@@ -84,12 +76,8 @@ abstract class GitHubChecksContext {
     }
 
     protected GitHubAppCredentials getGitHubAppCredentials(final String credentialsId) {
-        Optional<GitHubAppCredentials> foundCredentials = findGitHubAppCredentials(credentialsId);
-        if (!foundCredentials.isPresent()) {
-            throw new IllegalStateException("No GitHub APP credentials available for job: " + getJob().getName());
-        }
-
-        return foundCredentials.get();
+        return findGitHubAppCredentials(credentialsId).orElseThrow(() ->
+                new IllegalStateException("No GitHub APP credentials available for job: " + getJob().getName()));
     }
 
     protected boolean hasGitHubAppCredentials() {
@@ -113,7 +101,7 @@ abstract class GitHubChecksContext {
 
             return false;
         }
-        
+
         return true;
     }
 

--- a/src/main/java/io/jenkins/plugins/checks/github/GitHubChecksContext.java
+++ b/src/main/java/io/jenkins/plugins/checks/github/GitHubChecksContext.java
@@ -2,11 +2,11 @@ package io.jenkins.plugins.checks.github;
 
 import java.util.Optional;
 
+import edu.hm.hafner.util.FilteredLog;
 import org.apache.commons.lang3.StringUtils;
 import org.jenkinsci.plugins.github_branch_source.GitHubAppCredentials;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
-import io.jenkins.plugins.util.PluginLogger;
 
 import hudson.model.Job;
 
@@ -43,10 +43,10 @@ abstract class GitHubChecksContext {
      * Returns whether the context is valid (with all properties functional) to use.
      *
      * @param logger
-     *         the plugin logger
+     *         the filtered logger
      * @return whether the context is valid to use
      */
-    public abstract boolean isValid(PluginLogger logger);
+    public abstract boolean isValid(FilteredLog logger);
 
     @Nullable
     protected abstract String getCredentialsId();
@@ -95,16 +95,16 @@ abstract class GitHubChecksContext {
         return StringUtils.isNoneBlank(getCredentialsId());
     }
 
-    protected boolean hasValidCredentials(final PluginLogger logger) {
+    protected boolean hasValidCredentials(final FilteredLog logger) {
         if (!hasCredentialsId()) {
-            logger.log("No credentials found");
+            logger.logError("No credentials found");
 
             return false;
         }
 
         if (!hasGitHubAppCredentials()) {
-            logger.log("No GitHub app credentials found: '%s'", getCredentialsId());
-            logger.log("See: https://github.com/jenkinsci/github-branch-source-plugin/blob/master/docs/github-app.adoc");
+            logger.logError("No GitHub app credentials found: '%s'", getCredentialsId());
+            logger.logError("See: https://github.com/jenkinsci/github-branch-source-plugin/blob/master/docs/github-app.adoc");
 
             return false;
         }

--- a/src/main/java/io/jenkins/plugins/checks/github/GitHubChecksContext.java
+++ b/src/main/java/io/jenkins/plugins/checks/github/GitHubChecksContext.java
@@ -25,15 +25,6 @@ abstract class GitHubChecksContext {
     }
 
     /**
-     * Returns the Jenkins job.
-     *
-     * @return job for which the checks will be based on
-     */
-    public Job<?, ?> getJob() {
-        return job;
-    }
-
-    /**
      * Returns the commit sha of the run.
      *
      * @return the commit sha of the run or null
@@ -49,21 +40,26 @@ abstract class GitHubChecksContext {
     public abstract String getRepository();
 
     /**
+     * Returns whether the context is valid (with all properties functional) to use.
+     *
+     * @param logger
+     *         the plugin logger
+     * @return whether the context is valid to use
+     */
+    public abstract boolean isValid(PluginLogger logger);
+
+    @Nullable
+    protected abstract String getCredentialsId();
+
+    /**
      * Returns the credentials to access the remote GitHub repository.
      *
      * @return the credentials or null
      */
     public GitHubAppCredentials getCredentials() {
         String credentialsId = getCredentialsId();
-        if (credentialsId == null) {
-            throw new IllegalStateException("No credentials available for job: " + getJob().getName());
-        }
-
         return getGitHubAppCredentials(credentialsId);
     }
-
-    @Nullable
-    protected abstract String getCredentialsId();
 
     /**
      * Returns the URL of the run's summary page, e.g. https://ci.jenkins.io/job/Core/job/jenkins/job/master/2000/.
@@ -74,7 +70,11 @@ abstract class GitHubChecksContext {
         return url;
     }
 
-    SCMFacade getScmFacade() {
+    protected Job<?, ?> getJob() {
+        return job;
+    }
+
+    protected SCMFacade getScmFacade() {
         return scmFacade;
     }
 
@@ -86,12 +86,6 @@ abstract class GitHubChecksContext {
 
         return foundCredentials.get();
     }
-
-    Optional<GitHubAppCredentials> findGitHubAppCredentials(final String credentialsId) {
-        return getScmFacade().findGitHubAppCredentials(getJob(), credentialsId);
-    }
-
-    abstract boolean isValid(PluginLogger listener);
 
     protected boolean hasGitHubAppCredentials() {
         return findGitHubAppCredentials(getCredentialsId()).isPresent();
@@ -116,5 +110,9 @@ abstract class GitHubChecksContext {
         }
         
         return true;
+    }
+
+    private Optional<GitHubAppCredentials> findGitHubAppCredentials(final String credentialsId) {
+        return getScmFacade().findGitHubAppCredentials(getJob(), credentialsId);
     }
 }

--- a/src/main/java/io/jenkins/plugins/checks/github/GitHubChecksPublisher.java
+++ b/src/main/java/io/jenkins/plugins/checks/github/GitHubChecksPublisher.java
@@ -1,25 +1,20 @@
 package io.jenkins.plugins.checks.github;
 
+import edu.hm.hafner.util.VisibleForTesting;
+import io.jenkins.plugins.checks.api.ChecksDetails;
+import io.jenkins.plugins.checks.api.ChecksPublisher;
+import io.jenkins.plugins.util.PluginLogger;
+import org.apache.commons.lang3.StringUtils;
+import org.jenkinsci.plugins.github_branch_source.Connector;
+import org.jenkinsci.plugins.github_branch_source.GitHubAppCredentials;
+import org.kohsuke.github.GHCheckRunBuilder;
+import org.kohsuke.github.GitHub;
+
 import java.io.IOException;
 import java.time.Instant;
 import java.util.Date;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
-import io.jenkins.plugins.util.PluginLogger;
-import org.apache.commons.lang3.StringUtils;
-
-import edu.hm.hafner.util.VisibleForTesting;
-import edu.umd.cs.findbugs.annotations.CheckForNull;
-
-import org.kohsuke.github.GHCheckRunBuilder;
-import org.kohsuke.github.GitHub;
-import org.jenkinsci.plugins.github_branch_source.Connector;
-import org.jenkinsci.plugins.github_branch_source.GitHubAppCredentials;
-import hudson.model.TaskListener;
-
-import io.jenkins.plugins.checks.api.ChecksDetails;
-import io.jenkins.plugins.checks.api.ChecksPublisher;
 
 /**
  * A publisher which publishes GitHub check runs.

--- a/src/main/java/io/jenkins/plugins/checks/github/GitHubChecksPublisherFactory.java
+++ b/src/main/java/io/jenkins/plugins/checks/github/GitHubChecksPublisherFactory.java
@@ -50,7 +50,7 @@ public class GitHubChecksPublisherFactory extends ChecksPublisherFactory {
 
     private Optional<ChecksPublisher> createPublisher(final TaskListener listener, final GitHubChecksContext... contexts) {
         FilteredLog causeLogger = new FilteredLog("Causes for no suitable publisher found: ");
-        PluginLogger consoleLogger = createConsoleLogger(getListener(listener));
+        PluginLogger consoleLogger = new PluginLogger(listener.getLogger(), "GitHub Checks");
 
         for (GitHubChecksContext ctx : contexts) {
             if (ctx.isValid(causeLogger)) {
@@ -60,17 +60,5 @@ public class GitHubChecksPublisherFactory extends ChecksPublisherFactory {
 
         consoleLogger.logEachLine(causeLogger.getErrorMessages());
         return Optional.empty();
-    }
-
-    private TaskListener getListener(final TaskListener taskListener) {
-        // FIXME: checks-API should use a Null listener
-        if (taskListener == null) {
-            return TaskListener.NULL;
-        }
-        return taskListener;
-    }
-
-    private PluginLogger createConsoleLogger(final TaskListener listener) {
-        return new PluginLogger(listener.getLogger(), "GitHub Checks");
     }
 }

--- a/src/main/java/io/jenkins/plugins/checks/github/GitHubChecksPublisherFactory.java
+++ b/src/main/java/io/jenkins/plugins/checks/github/GitHubChecksPublisherFactory.java
@@ -54,7 +54,7 @@ public class GitHubChecksPublisherFactory extends ChecksPublisherFactory {
 
         for (GitHubChecksContext ctx : contexts) {
             if (ctx.isValid(causeLogger)) {
-                return Optional.of(new GitHubChecksPublisher(ctx, createConsoleLogger(getListener(listener))));
+                return Optional.of(new GitHubChecksPublisher(ctx, consoleLogger));
             }
         }
 

--- a/src/main/java/io/jenkins/plugins/checks/github/GitHubSCMSourceChecksContext.java
+++ b/src/main/java/io/jenkins/plugins/checks/github/GitHubSCMSourceChecksContext.java
@@ -2,11 +2,11 @@ package io.jenkins.plugins.checks.github;
 
 import java.util.Optional;
 
+import edu.hm.hafner.util.FilteredLog;
 import org.apache.commons.lang3.StringUtils;
 import org.jenkinsci.plugins.github_branch_source.GitHubSCMSource;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
-import io.jenkins.plugins.util.PluginLogger;
 import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMRevision;
 
@@ -65,9 +65,11 @@ class GitHubSCMSourceChecksContext extends GitHubChecksContext {
     }
 
     @Override
-    public boolean isValid(final PluginLogger logger) {
+    public boolean isValid(final FilteredLog logger) {
+        logger.logError("Trying to resolve checks parameters from GitHub SCM...");
+
         if (resolveSource() == null) {
-            logger.log("No GitHub SCM source found");
+            logger.logError("Job does not use GitHub SCM");
 
             return false;
         }
@@ -76,7 +78,13 @@ class GitHubSCMSourceChecksContext extends GitHubChecksContext {
             return false;
         }
 
-        return StringUtils.isNotBlank(sha);
+        if (StringUtils.isBlank(sha)) {
+            logger.logError("No HEAD SHA found for %s", getRepository());
+
+            return false;
+        }
+
+        return true;
     }
 
     @Override

--- a/src/main/java/io/jenkins/plugins/checks/github/GitHubSCMSourceChecksContext.java
+++ b/src/main/java/io/jenkins/plugins/checks/github/GitHubSCMSourceChecksContext.java
@@ -1,38 +1,32 @@
 package io.jenkins.plugins.checks.github;
 
-import java.util.Optional;
-
 import edu.hm.hafner.util.FilteredLog;
-import org.apache.commons.lang3.StringUtils;
-
-import edu.umd.cs.findbugs.annotations.Nullable;
-import edu.hm.hafner.util.VisibleForTesting;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
-
-import org.jenkinsci.plugins.displayurlapi.DisplayURLProvider;
-import org.jenkinsci.plugins.github_branch_source.GitHubSCMSource;
-import org.jenkinsci.plugins.github_branch_source.PullRequestSCMRevision;
 import hudson.model.Job;
 import hudson.model.Run;
-import jenkins.plugins.git.AbstractGitSCMSource;
 import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMRevision;
+import org.apache.commons.lang3.StringUtils;
+import org.jenkinsci.plugins.github_branch_source.GitHubSCMSource;
 
-import io.jenkins.plugins.util.PluginLogger;
+import java.util.Optional;
 
 /**
  * Provides a {@link GitHubChecksContext} for a Jenkins job that uses a supported {@link GitHubSCMSource}.
  */
 class GitHubSCMSourceChecksContext extends GitHubChecksContext {
-    @Nullable
+    @CheckForNull
     private final String sha;
 
     /**
      * Creates a {@link GitHubSCMSourceChecksContext} according to the run. All attributes are computed during this period.
      *
-     * @param run a run of a GitHub Branch Source project
-     * @param runURL the URL to the Jenkins run
-     * @param scmFacade a facade for Jenkins SCM
+     * @param run
+     *         a run of a GitHub Branch Source project
+     * @param runURL
+     *         the URL to the Jenkins run
+     * @param scmFacade
+     *         a facade for Jenkins SCM
      */
     GitHubSCMSourceChecksContext(final Run<?, ?> run, final String runURL, final SCMFacade scmFacade) {
         super(run.getParent(), runURL, scmFacade);
@@ -42,9 +36,12 @@ class GitHubSCMSourceChecksContext extends GitHubChecksContext {
     /**
      * Creates a {@link GitHubSCMSourceChecksContext} according to the job. All attributes are computed during this period.
      *
-     * @param job a GitHub Branch Source project
-     * @param jobURL the URL to the Jenkins job
-     * @param scmFacade a facade for Jenkins SCM
+     * @param job
+     *         a GitHub Branch Source project
+     * @param jobURL
+     *         the URL to the Jenkins job
+     * @param scmFacade
+     *         a facade for Jenkins SCM
      */
     GitHubSCMSourceChecksContext(final Job<?, ?> job, final String jobURL, final SCMFacade scmFacade) {
         super(job, jobURL, scmFacade);
@@ -71,11 +68,6 @@ class GitHubSCMSourceChecksContext extends GitHubChecksContext {
         }
     }
 
-    @Override @CheckForNull
-    protected String getCredentialsId() {
-        return resolveSource().getCredentialsId();
-    }
-
     @Override
     public boolean isValid(final FilteredLog logger) {
         logger.logError("Trying to resolve checks parameters from GitHub SCM...");
@@ -100,7 +92,7 @@ class GitHubSCMSourceChecksContext extends GitHubChecksContext {
     }
 
     @Override
-    @Nullable
+    @CheckForNull
     protected String getCredentialsId() {
         GitHubSCMSource source = resolveSource();
         if (source == null) {
@@ -110,12 +102,12 @@ class GitHubSCMSourceChecksContext extends GitHubChecksContext {
         return source.getCredentialsId();
     }
 
-    @Nullable
+    @CheckForNull
     private GitHubSCMSource resolveSource() {
         return getScmFacade().findGitHubSCMSource(getJob()).orElse(null);
     }
 
-    @Nullable
+    @CheckForNull
     private String resolveHeadSha(final Run<?, ?> run) {
         GitHubSCMSource source = resolveSource();
         if (source != null) {
@@ -128,7 +120,7 @@ class GitHubSCMSourceChecksContext extends GitHubChecksContext {
         return null;
     }
 
-    @Nullable
+    @CheckForNull
     private String resolveHeadSha(final Job<?, ?> job) {
         GitHubSCMSource source = resolveSource();
         Optional<SCMHead> head = getScmFacade().findHead(job);

--- a/src/main/java/io/jenkins/plugins/checks/github/GitSCMChecksContext.java
+++ b/src/main/java/io/jenkins/plugins/checks/github/GitSCMChecksContext.java
@@ -3,11 +3,10 @@ package io.jenkins.plugins.checks.github;
 import java.io.IOException;
 import java.util.Optional;
 
-import edu.hm.hafner.util.VisibleForTesting;
+import edu.hm.hafner.util.FilteredLog;
 import org.apache.commons.lang3.StringUtils;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
-import io.jenkins.plugins.util.PluginLogger;
 
 import hudson.model.Run;
 import hudson.model.TaskListener;
@@ -105,16 +104,18 @@ class GitSCMChecksContext extends GitHubChecksContext {
     }
 
     @Override
-    public boolean isValid(final PluginLogger logger) {
+    public boolean isValid(final FilteredLog logger) {
+        logger.logError("Trying to resolve checks parameters from Git SCM...");
+
         if (!getScmFacade().findGitSCM(run).isPresent()) {
-            logger.log("Job does not use GitSCM");
+            logger.logError("Job does not use Git SCM");
 
             return false;
         }
 
         String remoteUrl = getRemoteUrl();
         if (!isValidUrl(remoteUrl)) {
-            logger.log("No supported GitSCM repository URL: " + remoteUrl);
+            logger.logError("No supported GitSCM repository URL: " + remoteUrl);
 
             return false;
         }
@@ -125,12 +126,12 @@ class GitSCMChecksContext extends GitHubChecksContext {
 
         String repository = getRepository();
         if (getHeadSha().isEmpty()) {
-            logger.log("No HEAD SHA found for '%s'", repository);
+            logger.logError("No HEAD SHA found for '%s'", repository);
 
             return false;
         }
 
-        logger.log("Using GitSCM repository '%s' for GitHub checks", repository);
+        logger.logInfo("Using GitSCM repository '%s' for GitHub checks", repository);
 
         return true;
     }

--- a/src/main/java/io/jenkins/plugins/checks/github/GitSCMChecksContext.java
+++ b/src/main/java/io/jenkins/plugins/checks/github/GitSCMChecksContext.java
@@ -35,7 +35,6 @@ class GitSCMChecksContext extends GitHubChecksContext {
         this(run, runURL, new SCMFacade());
     }
 
-    @VisibleForTesting
     GitSCMChecksContext(final Run<?, ?> run, final String runURL, final SCMFacade scmFacade) {
         super(run.getParent(), runURL, scmFacade);
 

--- a/src/main/java/io/jenkins/plugins/checks/github/GitSCMChecksContext.java
+++ b/src/main/java/io/jenkins/plugins/checks/github/GitSCMChecksContext.java
@@ -1,21 +1,17 @@
 package io.jenkins.plugins.checks.github;
 
-import java.io.IOException;
-import java.util.Optional;
-
 import edu.hm.hafner.util.FilteredLog;
-import org.apache.commons.lang3.StringUtils;
-
 import edu.umd.cs.findbugs.annotations.CheckForNull;
-
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.Revision;
 import hudson.plugins.git.UserRemoteConfig;
 import hudson.plugins.git.util.BuildData;
+import org.apache.commons.lang3.StringUtils;
 
-import io.jenkins.plugins.util.PluginLogger;
+import java.io.IOException;
+import java.util.Optional;
 
 /**
  * Provides a {@link GitHubChecksContext} for a Jenkins job that uses a supported {@link GitSCM}.
@@ -87,7 +83,8 @@ class GitSCMChecksContext extends GitHubChecksContext {
         return StringUtils.removeStart(StringUtils.removeStart(url, GIT_PROTOCOL), HTTPS_PROTOCOL);
     }
 
-    @Override @CheckForNull
+    @Override
+    @CheckForNull
     protected String getCredentialsId() {
         return getUserRemoteConfig().getCredentialsId();
     }
@@ -139,7 +136,7 @@ class GitSCMChecksContext extends GitHubChecksContext {
     }
 
     private boolean isValidUrl(@CheckForNull final String remoteUrl) {
-        return StringUtils.startsWith(remoteUrl, GIT_PROTOCOL) 
+        return StringUtils.startsWith(remoteUrl, GIT_PROTOCOL)
                 || StringUtils.startsWith(remoteUrl, HTTPS_PROTOCOL);
     }
 }

--- a/src/main/java/io/jenkins/plugins/checks/github/GitSCMChecksContext.java
+++ b/src/main/java/io/jenkins/plugins/checks/github/GitSCMChecksContext.java
@@ -3,6 +3,7 @@ package io.jenkins.plugins.checks.github;
 import java.io.IOException;
 import java.util.Optional;
 
+import edu.hm.hafner.util.VisibleForTesting;
 import org.apache.commons.lang3.StringUtils;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -31,7 +32,12 @@ class GitSCMChecksContext extends GitHubChecksContext {
      * @param runURL the URL to the Jenkins run
      */
     GitSCMChecksContext(final Run<?, ?> run, final String runURL) {
-        super(run.getParent(), runURL, new SCMFacade());
+        this(run, runURL, new SCMFacade());
+    }
+
+    @VisibleForTesting
+    GitSCMChecksContext(final Run<?, ?> run, final String runURL, final SCMFacade scmFacade) {
+        super(run.getParent(), runURL, scmFacade);
 
         this.run = run;
     }
@@ -100,7 +106,7 @@ class GitSCMChecksContext extends GitHubChecksContext {
     }
 
     @Override
-    boolean isValid(final PluginLogger logger) {
+    public boolean isValid(final PluginLogger logger) {
         if (!getScmFacade().findGitSCM(run).isPresent()) {
             logger.log("Job does not use GitSCM");
 

--- a/src/main/java/io/jenkins/plugins/checks/github/SCMFacade.java
+++ b/src/main/java/io/jenkins/plugins/checks/github/SCMFacade.java
@@ -6,8 +6,11 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
+import jenkins.plugins.git.AbstractGitSCMSource;
+import jenkins.scm.api.SCMRevisionAction;
 import org.jenkinsci.plugins.github_branch_source.GitHubAppCredentials;
 import org.jenkinsci.plugins.github_branch_source.GitHubSCMSource;
+import org.jenkinsci.plugins.github_branch_source.PullRequestSCMRevision;
 import org.jenkinsci.plugins.workflow.cps.CpsScmFlowDefinition;
 import org.jenkinsci.plugins.workflow.flow.FlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
@@ -133,6 +136,39 @@ public class SCMFacade {
         catch (IOException | InterruptedException e) {
             throw new IllegalStateException(String.format("Could not fetch revision from repository: %s and branch: %s",
                     source.getId(), head.getName()), e);
+        }
+    }
+
+    /**
+     * Find the current {@link SCMRevision} of the {@code source} and {@code run} locally through
+     * {@link jenkins.scm.api.SCMRevisionAction}.
+     *
+     * @param source
+     *         the GitHub repository
+     * @param run
+     *         the Jenkins run
+     * @return the found revision or empty
+     */
+    public Optional<SCMRevision> findRevision(final GitHubSCMSource source, final Run<?, ?> run) {
+        return Optional.ofNullable(SCMRevisionAction.getRevision(source, run));
+    }
+
+    /**
+     * Find the hash value in {@code revision}.
+     *
+     * @param revision
+     *         the revision for a build
+     * @return the found hash or empty
+     */
+    public Optional<String> findHash(final SCMRevision revision) {
+        if (revision instanceof AbstractGitSCMSource.SCMRevisionImpl) {
+            return Optional.of(((AbstractGitSCMSource.SCMRevisionImpl) revision).getHash());
+        }
+        else if (revision instanceof PullRequestSCMRevision) {
+            return Optional.of(((PullRequestSCMRevision) revision).getPullHash());
+        }
+        else {
+            return Optional.empty();
         }
     }
 

--- a/src/test/java/io/jenkins/plugins/checks/github/GitHubChecksPublisherFactoryTest.java
+++ b/src/test/java/io/jenkins/plugins/checks/github/GitHubChecksPublisherFactoryTest.java
@@ -1,18 +1,16 @@
 package io.jenkins.plugins.checks.github;
 
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 import java.util.Optional;
 
 import hudson.EnvVars;
 import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.UserRemoteConfig;
-import io.jenkins.plugins.util.PluginLogger;
 import jenkins.scm.api.SCMHead;
-import jenkins.scm.api.SCMRevision;
 import org.jenkinsci.plugins.github_branch_source.GitHubAppCredentials;
 import org.jenkinsci.plugins.github_branch_source.GitHubSCMSource;
 import org.jenkinsci.plugins.github_branch_source.PullRequestSCMRevision;
-import org.junit.Ignore;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.*;
@@ -27,7 +25,7 @@ class GitHubChecksPublisherFactoryTest {
     private static final String URL = "URL";
 
     @Test
-    void shouldCreateGitHubChecksPublisherFromRunForProjectWithValidGitHubSCMSource() {
+    void shouldCreateGitHubChecksPublisherFromRunForProjectWithValidGitHubSCMSource() throws UnsupportedEncodingException {
         Run run = mock(Run.class);
         Job job = mock(Job.class);
         GitHubSCMSource source = mock(GitHubSCMSource.class);
@@ -49,7 +47,7 @@ class GitHubChecksPublisherFactoryTest {
     }
 
     @Test
-    void shouldReturnGitHubChecksPublisherFromJobProjectWithValidGitHubSCMSource() {
+    void shouldReturnGitHubChecksPublisherFromJobProjectWithValidGitHubSCMSource() throws UnsupportedEncodingException {
         Run run = mock(Run.class);
         Job job = mock(Job.class);
         GitHubSCMSource source = mock(GitHubSCMSource.class);
@@ -98,7 +96,7 @@ class GitHubChecksPublisherFactoryTest {
     }
 
     @Test
-    void shouldReturnEmptyFromRunForInvalidProject() {
+    void shouldReturnEmptyFromRunForInvalidProject() throws UnsupportedEncodingException {
         Run run = mock(Run.class);
 
         GitHubChecksPublisherFactory factory = new GitHubChecksPublisherFactory();
@@ -107,7 +105,7 @@ class GitHubChecksPublisherFactoryTest {
     }
 
     @Test
-    void shouldCreateNullPublisherFromJobForInvalidProject() {
+    void shouldCreateNullPublisherFromJobForInvalidProject() throws UnsupportedEncodingException {
         Job job = mock(Job.class);
 
         GitHubChecksPublisherFactory factory = new GitHubChecksPublisherFactory();

--- a/src/test/java/io/jenkins/plugins/checks/github/GitHubChecksPublisherFactoryTest.java
+++ b/src/test/java/io/jenkins/plugins/checks/github/GitHubChecksPublisherFactoryTest.java
@@ -1,7 +1,6 @@
 package io.jenkins.plugins.checks.github;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.util.Optional;
 
 import hudson.EnvVars;
@@ -25,7 +24,7 @@ class GitHubChecksPublisherFactoryTest {
     private static final String URL = "URL";
 
     @Test
-    void shouldCreateGitHubChecksPublisherFromRunForProjectWithValidGitHubSCMSource() throws UnsupportedEncodingException {
+    void shouldCreateGitHubChecksPublisherFromRunForProjectWithValidGitHubSCMSource() throws IOException {
         Run run = mock(Run.class);
         Job job = mock(Job.class);
         GitHubSCMSource source = mock(GitHubSCMSource.class);
@@ -47,7 +46,7 @@ class GitHubChecksPublisherFactoryTest {
     }
 
     @Test
-    void shouldReturnGitHubChecksPublisherFromJobProjectWithValidGitHubSCMSource() throws UnsupportedEncodingException {
+    void shouldReturnGitHubChecksPublisherFromJobProjectWithValidGitHubSCMSource() throws IOException {
         Run run = mock(Run.class);
         Job job = mock(Job.class);
         GitHubSCMSource source = mock(GitHubSCMSource.class);
@@ -96,7 +95,7 @@ class GitHubChecksPublisherFactoryTest {
     }
 
     @Test
-    void shouldReturnEmptyFromRunForInvalidProject() throws UnsupportedEncodingException {
+    void shouldReturnEmptyFromRunForInvalidProject() throws IOException {
         Run run = mock(Run.class);
 
         GitHubChecksPublisherFactory factory = new GitHubChecksPublisherFactory();
@@ -105,7 +104,7 @@ class GitHubChecksPublisherFactoryTest {
     }
 
     @Test
-    void shouldCreateNullPublisherFromJobForInvalidProject() throws UnsupportedEncodingException {
+    void shouldCreateNullPublisherFromJobForInvalidProject() throws IOException {
         Job job = mock(Job.class);
 
         GitHubChecksPublisherFactory factory = new GitHubChecksPublisherFactory();

--- a/src/test/java/io/jenkins/plugins/checks/github/GitHubChecksPublisherFactoryTest.java
+++ b/src/test/java/io/jenkins/plugins/checks/github/GitHubChecksPublisherFactoryTest.java
@@ -1,9 +1,18 @@
 package io.jenkins.plugins.checks.github;
 
+import java.io.IOException;
 import java.util.Optional;
 
+import hudson.EnvVars;
+import hudson.plugins.git.GitSCM;
+import hudson.plugins.git.UserRemoteConfig;
+import io.jenkins.plugins.util.PluginLogger;
+import jenkins.scm.api.SCMHead;
+import jenkins.scm.api.SCMRevision;
 import org.jenkinsci.plugins.github_branch_source.GitHubAppCredentials;
 import org.jenkinsci.plugins.github_branch_source.GitHubSCMSource;
+import org.jenkinsci.plugins.github_branch_source.PullRequestSCMRevision;
+import org.junit.Ignore;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.*;
@@ -18,42 +27,78 @@ class GitHubChecksPublisherFactoryTest {
     private static final String URL = "URL";
 
     @Test
-    void shouldCreateGitHubChecksPublisherFromRun() {
+    void shouldCreateGitHubChecksPublisherFromRunForProjectWithValidGitHubSCMSource() {
         Run run = mock(Run.class);
         Job job = mock(Job.class);
         GitHubSCMSource source = mock(GitHubSCMSource.class);
         GitHubAppCredentials credentials = mock(GitHubAppCredentials.class);
+        PullRequestSCMRevision revision = mock(PullRequestSCMRevision.class);
         SCMFacade scmFacade = mock(SCMFacade.class);
 
         when(run.getParent()).thenReturn(job);
+        when(job.getLastBuild()).thenReturn(run);
         when(scmFacade.findGitHubSCMSource(job)).thenReturn(Optional.of(source));
         when(source.getCredentialsId()).thenReturn("credentials id");
         when(scmFacade.findGitHubAppCredentials(job, "credentials id")).thenReturn(Optional.of(credentials));
+        when(scmFacade.findRevision(source, run)).thenReturn(Optional.of(revision));
+        when(scmFacade.findHash(revision)).thenReturn(Optional.of("a1b2c3"));
 
         GitHubChecksPublisherFactory factory = new GitHubChecksPublisherFactory(scmFacade);
         assertThat(factory.createPublisher(run, URL, TaskListener.NULL))
-                .isPresent()
                 .containsInstanceOf(GitHubChecksPublisher.class);
     }
 
     @Test
-    void shouldReturnGitHubChecksPublisherFromJob() {
-        Job<?, ?> job = mock(Job.class);
+    void shouldReturnGitHubChecksPublisherFromJobProjectWithValidGitHubSCMSource() {
+        Run run = mock(Run.class);
+        Job job = mock(Job.class);
         GitHubSCMSource source = mock(GitHubSCMSource.class);
+        GitHubAppCredentials credentials = mock(GitHubAppCredentials.class);
+        PullRequestSCMRevision revision = mock(PullRequestSCMRevision.class);
+        SCMHead head = mock(SCMHead.class);
         SCMFacade scmFacade = mock(SCMFacade.class);
 
+        when(run.getParent()).thenReturn(job);
+        when(job.getLastBuild()).thenReturn(run);
         when(scmFacade.findGitHubSCMSource(job)).thenReturn(Optional.of(source));
         when(source.getCredentialsId()).thenReturn("credentials id");
-        when(scmFacade.findGitHubAppCredentials(job, "credentials id"))
-                .thenReturn(Optional.empty());
+        when(scmFacade.findGitHubAppCredentials(job, "credentials id")).thenReturn(Optional.of(credentials));
+        when(scmFacade.findHead(job)).thenReturn(Optional.of(head));
+        when(scmFacade.findRevision(source, head)).thenReturn(Optional.of(revision));
+        when(scmFacade.findHash(revision)).thenReturn(Optional.of("a1b2c3"));
 
         GitHubChecksPublisherFactory factory = new GitHubChecksPublisherFactory(scmFacade);
         assertThat(factory.createPublisher(job, URL, TaskListener.NULL))
-                .isNotPresent();
+                .containsInstanceOf(GitHubChecksPublisher.class);
     }
 
     @Test
-    void shouldReturnEmptyWhenNoGitHubSCMSourceIsConfigured() {
+    void shouldCreateGitHubChecksPublisherFromRunForProjectWithValidGitSCM() throws IOException, InterruptedException {
+        Job job = mock(Job.class);
+        Run run = mock(Run.class);
+        GitSCM gitSCM = mock(GitSCM.class);
+        UserRemoteConfig config = mock(UserRemoteConfig.class);
+        GitHubAppCredentials credentials = mock(GitHubAppCredentials.class);
+        SCMFacade scmFacade = mock(SCMFacade.class);
+        EnvVars envVars = mock(EnvVars.class);
+
+        when(run.getParent()).thenReturn(job);
+        when(run.getEnvironment(TaskListener.NULL)).thenReturn(envVars);
+        when(envVars.get("GIT_COMMIT")).thenReturn("a1b2c3");
+        when(scmFacade.getScm(job)).thenReturn(gitSCM);
+        when(scmFacade.findGitSCM(run)).thenReturn(Optional.of(gitSCM));
+        when(scmFacade.getUserRemoteConfig(gitSCM)).thenReturn(config);
+        when(config.getCredentialsId()).thenReturn("1");
+        when(scmFacade.findGitHubAppCredentials(job, "1")).thenReturn(Optional.of(credentials));
+        when(config.getUrl()).thenReturn("https://github.com/jenkinsci/github-checks-plugin");
+
+        GitHubChecksPublisherFactory factory = new GitHubChecksPublisherFactory(scmFacade);
+        assertThat(factory.createPublisher(run, URL, TaskListener.NULL))
+                .containsInstanceOf(GitHubChecksPublisher.class);
+    }
+
+    @Test
+    void shouldReturnEmptyFromRunForInvalidProject() {
         Run run = mock(Run.class);
 
         GitHubChecksPublisherFactory factory = new GitHubChecksPublisherFactory();
@@ -62,35 +107,10 @@ class GitHubChecksPublisherFactoryTest {
     }
 
     @Test
-    void shouldReturnEmptyWhenNoCredentialsIsConfigured() {
-        Run run = mock(Run.class);
+    void shouldCreateNullPublisherFromJobForInvalidProject() {
         Job job = mock(Job.class);
-        GitHubSCMSource source = mock(GitHubSCMSource.class);
-        SCMFacade scmFacade = mock(SCMFacade.class);
 
-        when(run.getParent()).thenReturn(job);
-        when(scmFacade.findGitHubSCMSource(run.getParent())).thenReturn(Optional.of(source));
-        when(source.getCredentialsId()).thenReturn(null);
-
-        GitHubChecksPublisherFactory factory = new GitHubChecksPublisherFactory(scmFacade);
-        assertThat(factory.createPublisher(job, URL, TaskListener.NULL))
-                .isNotPresent();
-    }
-
-    @Test
-    void shouldReturnEmptyWhenNoGitHubAppCredentialsIsConfigured() {
-        Run run = mock(Run.class);
-        Job job = mock(Job.class);
-        GitHubSCMSource source = mock(GitHubSCMSource.class);
-        SCMFacade scmFacade = mock(SCMFacade.class);
-
-        when(run.getParent()).thenReturn(job);
-        when(scmFacade.findGitHubSCMSource(run.getParent())).thenReturn(Optional.of(source));
-        when(source.getCredentialsId()).thenReturn("credentials id");
-        when(scmFacade.findGitHubAppCredentials(run.getParent(), "credentials id"))
-                .thenReturn(Optional.empty());
-
-        GitHubChecksPublisherFactory factory = new GitHubChecksPublisherFactory(scmFacade);
+        GitHubChecksPublisherFactory factory = new GitHubChecksPublisherFactory();
         assertThat(factory.createPublisher(job, URL, TaskListener.NULL))
                 .isNotPresent();
     }

--- a/src/test/java/io/jenkins/plugins/checks/github/GitHubChecksPublisherITest.java
+++ b/src/test/java/io/jenkins/plugins/checks/github/GitHubChecksPublisherITest.java
@@ -7,6 +7,7 @@ import java.util.Collections;
 import java.util.Optional;
 import java.util.logging.Level;
 
+import io.jenkins.plugins.util.PluginLogger;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
@@ -109,7 +110,8 @@ public class GitHubChecksPublisherITest {
                         new ChecksAction("re-run", "re-run Jenkins build", "#0")))
                 .build();
 
-        new GitHubChecksPublisher(createGitHubChecksContextWithGitHubSCM(), jenkinsRule.createTaskListener(),
+        new GitHubChecksPublisher(createGitHubChecksContextWithGitHubSCM(),
+                new PluginLogger(jenkinsRule.createTaskListener().getLogger(), "GitHub Checks"),
                 wireMockRule.baseUrl())
                 .publish(details);
     }
@@ -142,7 +144,8 @@ public class GitHubChecksPublisherITest {
                         .build())
                 .build();
 
-        new GitHubChecksPublisher(createGitHubChecksContextWithGitHubSCM(), jenkinsRule.createTaskListener(),
+        new GitHubChecksPublisher(createGitHubChecksContextWithGitHubSCM(),
+                new PluginLogger(jenkinsRule.createTaskListener().getLogger(), "GitHub Checks"),
                 wireMockRule.baseUrl())
                 .publish(details);
 
@@ -174,16 +177,18 @@ public class GitHubChecksPublisherITest {
         ClassicDisplayURLProvider urlProvider = mock(ClassicDisplayURLProvider.class);
 
         when(run.getParent()).thenReturn(job);
+        when(job.getLastBuild()).thenReturn(run);
+
         when(source.getCredentialsId()).thenReturn("1");
         when(source.getRepoOwner()).thenReturn("XiongKezhi");
         when(source.getRepository()).thenReturn("Sandbox");
-        when(revision.getPullHash()).thenReturn("18c8e2fd86e7aa3748e279c14a00dc3f0b963e7f");
         when(credentials.getPassword()).thenReturn(Secret.fromString("password"));
 
         when(scmFacade.findGitHubSCMSource(job)).thenReturn(Optional.of(source));
         when(scmFacade.findGitHubAppCredentials(job, "1")).thenReturn(Optional.of(credentials));
         when(scmFacade.findHead(job)).thenReturn(Optional.of(head));
-        when(scmFacade.findRevision(source, head)).thenReturn(Optional.of(revision));
+        when(scmFacade.findRevision(source, run)).thenReturn(Optional.of(revision));
+        when(scmFacade.findHash(revision)).thenReturn(Optional.of("18c8e2fd86e7aa3748e279c14a00dc3f0b963e7f"));
 
         when(urlProvider.getRunURL(run)).thenReturn("https://ci.jenkins.io");
 

--- a/src/test/java/io/jenkins/plugins/checks/github/GitHubSCMSourceChecksContextTest.java
+++ b/src/test/java/io/jenkins/plugins/checks/github/GitHubSCMSourceChecksContextTest.java
@@ -190,7 +190,7 @@ class GitHubSCMSourceChecksContextTest {
     }
 
     @Test
-    void shouldReturnFalseWhenValidateContextWhenCredentialsIsNotValid() {
+    void shouldReturnFalseWhenValidateContextButHasNoValidCredentials() {
         Job<?, ?> job = mock(Job.class);
         GitHubSCMSource source = mock(GitHubSCMSource.class);
         FilteredLog logger = new FilteredLog("");
@@ -202,7 +202,23 @@ class GitHubSCMSourceChecksContextTest {
     }
 
     @Test
-    void shouldReturnFalseWhenValidateContextWhenNoSHA() {
+    void shouldReturnFalseWhenValidateContextButHasNoValidGitHubAppCredentials() {
+        Job<?, ?> job = mock(Job.class);
+        GitHubSCMSource source = mock(GitHubSCMSource.class);
+        FilteredLog logger = new FilteredLog("");
+
+        when(source.getCredentialsId()).thenReturn("oauth-credentials");
+
+        assertThat(new GitHubSCMSourceChecksContext(job, URL, createGitHubSCMFacadeWithSource(job, source))
+                .isValid(logger))
+                .isFalse();
+        assertThat(logger.getErrorMessages())
+                .contains("No GitHub app credentials found: 'oauth-credentials'")
+                .contains("See: https://github.com/jenkinsci/github-branch-source-plugin/blob/master/docs/github-app.adoc");
+    }
+
+    @Test
+    void shouldReturnFalseWhenValidateContextButHasNoValidSHA() {
         Run run = mock(Run.class);
         Job job = mock(Job.class);
         GitHubSCMSource source = mock(GitHubSCMSource.class);

--- a/src/test/java/io/jenkins/plugins/checks/github/GitHubSCMSourceChecksContextTest.java
+++ b/src/test/java/io/jenkins/plugins/checks/github/GitHubSCMSourceChecksContextTest.java
@@ -159,19 +159,21 @@ class GitHubSCMSourceChecksContextTest {
     void shouldGetURLForJob() {
         Job job = mock(Job.class);
 
-        assertThat(new GitHubSCMSourceChecksContext(job, URL, null).getURL())
+        assertThat(new GitHubSCMSourceChecksContext(job, URL, createGitHubSCMFacadeWithSource(job, null)).getURL())
                 .isEqualTo(URL);
     }
 
     @Test
     void shouldGetURLForRun() {
         Run<?, ?> run = mock(Run.class);
+        Job<?, ?> job = mock(Job.class);
         ClassicDisplayURLProvider urlProvider = mock(ClassicDisplayURLProvider.class);
 
         when(urlProvider.getRunURL(run))
                 .thenReturn("http://127.0.0.1:8080/job/github-checks-plugin/job/master/200");
 
-        assertThat(new GitHubSCMSourceChecksContext(run, urlProvider.getRunURL(run), null).getURL())
+        assertThat(new GitHubSCMSourceChecksContext(run, urlProvider.getRunURL(run),
+                createGitHubSCMFacadeWithSource(job, null)).getURL())
                 .isEqualTo("http://127.0.0.1:8080/job/github-checks-plugin/job/master/200");
     }
 


### PR DESCRIPTION
When creating publisher, check whether all `ChecksContext` parameters are available using `isValid` method before returning the `GitHubChecksPublisher`; if some parameters are not, return `Optional.empty()`, thus a `NullPublisher` will be used.