### PR TITLE
Cleanup pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,11 +26,8 @@
 
     <!-- Jenkins Plug-in Dependencies Versions -->
     <checks-api.version>1.0.0</checks-api.version>
-    <plugin-util-api.version>1.2.5</plugin-util-api.version>
-    <github-api.version>1.116</github-api.version>
+    <plugin-util-api.version>1.3.0</plugin-util-api.version>
     <github-branch-source.version>2.9.1</github-branch-source.version>
-    <github-plugin.version>1.31.0</github-plugin.version>
-    <branch-api.version>2.6.0</branch-api.version>
 
     <!-- Test Library Dependencies Versions -->
     <jetty.version>9.4.32.v20200930</jetty.version>
@@ -89,35 +86,8 @@
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>github-api</artifactId>
-      <version>${github-api.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>github-branch-source</artifactId>
       <version>${github-branch-source.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.coravy.hudson.plugins.github</groupId>
-      <artifactId>github</artifactId>
-      <version>${github-plugin.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>branch-api</artifactId>
-      <version>${branch-api.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>git</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>git-client</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins.workflow</groupId>
-      <artifactId>workflow-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>


### PR DESCRIPTION
Helps with: https://github.com/jenkinsci/junit-plugin/pull/180, means I don't need to add the branch-api to to the plugin as an explicit dep

All of these deps are already being pulled transitively and have the same or similar versions via bom