### PR TITLE
Fix check reporting when using shared library

### DIFF
--- a/src/main/java/io/jenkins/plugins/checks/github/GitHubChecksPublisherFactory.java
+++ b/src/main/java/io/jenkins/plugins/checks/github/GitHubChecksPublisherFactory.java
@@ -39,8 +39,8 @@ public class GitHubChecksPublisherFactory extends ChecksPublisherFactory {
     @Override
     protected Optional<ChecksPublisher> createPublisher(final Run<?, ?> run, final TaskListener listener) {
         final String runURL = urlProvider.getRunURL(run);
-        return createPublisher(listener, new GitSCMChecksContext(run, runURL, scmFacade),
-                new GitHubSCMSourceChecksContext(run, runURL, scmFacade));
+        return createPublisher(listener, new GitHubSCMSourceChecksContext(run, runURL, scmFacade),
+                new GitSCMChecksContext(run, runURL, scmFacade));
     }
 
     @Override


### PR DESCRIPTION
Fixes https://github.com/jenkinsci/github-checks-plugin/issues/50

`GitSCMChecksContext` doesn't resolve the git commit properly when shared libraries are involved.

`GitHubSCMSourceChecksContext` resolves fine, 

Only the first context is consulted if it can look one up.

`GitSCMChecksContext` might be fixable (no real point as in 99% of cases it's just freestyle builds afaik which don't have libraries), but for now this is a tiny fix to a very annoying issue.