### PR TITLE
Avoid explicit adding staus checks properties to publish status checks.

### DIFF
--- a/src/main/java/io/jenkins/plugins/checks/github/status/GitHubStatusChecksProperties.java
+++ b/src/main/java/io/jenkins/plugins/checks/github/status/GitHubStatusChecksProperties.java
@@ -34,7 +34,7 @@ public class GitHubStatusChecksProperties implements StatusChecksProperties {
 
     @Override
     public boolean isApplicable(final Job<?, ?> job) {
-        return getConfigurations(job).isPresent();
+        return scmFacade.findGitHubSCMSource(job).isPresent() || scmFacade.findGitSCM(job).isPresent();
     }
 
     @Override

--- a/src/test/java/io/jenkins/plugins/checks/github/status/GitHubStatusChecksPropertiesTest.java
+++ b/src/test/java/io/jenkins/plugins/checks/github/status/GitHubStatusChecksPropertiesTest.java
@@ -59,7 +59,7 @@ class GitHubStatusChecksPropertiesTest {
         when(scmFacade.findGitHubSCMSource(job)).thenReturn(Optional.of(source));
 
         assertJobWithStatusChecksProperties(job, new GitHubStatusChecksProperties(scmFacade),
-                false, "Jenkins", false);
+                true, "Jenkins", false);
     }
 
     @Test
@@ -73,7 +73,7 @@ class GitHubStatusChecksPropertiesTest {
         when(scm.getExtensions()).thenReturn(extensionList);
 
         assertJobWithStatusChecksProperties(job, new GitHubStatusChecksProperties(scmFacade),
-                false, "Jenkins", false);
+                true, "Jenkins", false);
     }
 
     @Test


### PR DESCRIPTION
See https://github.com/jenkinsci/github-checks-plugin/issues/79.