### PR TITLE
Update checks by name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -188,6 +188,12 @@
       <version>20.0</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-inline</artifactId>
+      <version>${mockito.version}</version>
+      <scope>test</scope>
+    </dependency>
     <!-- stage -->
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,11 @@
       <version>${github-branch-source.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.kohsuke</groupId>
+      <artifactId>github-api</artifactId>
+      <version>1.117</version>
+    </dependency>
+    <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-cps</artifactId>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
       <version>${github-branch-source.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.kohsuke</groupId>
+      <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>github-api</artifactId>
       <version>1.117</version>
     </dependency>

--- a/src/main/java/io/jenkins/plugins/checks/github/GitHubChecksAction.java
+++ b/src/main/java/io/jenkins/plugins/checks/github/GitHubChecksAction.java
@@ -3,13 +3,15 @@ package io.jenkins.plugins.checks.github;
 import hudson.model.InvisibleAction;
 import io.jenkins.plugins.checks.api.ChecksConclusion;
 
+@SuppressWarnings("PMD.DataClass")
 public class GitHubChecksAction extends InvisibleAction {
 
     private final long id;
     private final String name;
     private ChecksConclusion conclusion;
 
-    public GitHubChecksAction(long id, String name, ChecksConclusion conclusion) {
+    public GitHubChecksAction(final long id, final String name, final ChecksConclusion conclusion) {
+        super();
         this.id = id;
         this.name = name;
         this.conclusion = conclusion;
@@ -27,7 +29,7 @@ public class GitHubChecksAction extends InvisibleAction {
         return conclusion;
     }
 
-    public void setConclusion(ChecksConclusion conclusion) {
+    public void setConclusion(final ChecksConclusion conclusion) {
         this.conclusion = conclusion;
     }
 

--- a/src/main/java/io/jenkins/plugins/checks/github/GitHubChecksAction.java
+++ b/src/main/java/io/jenkins/plugins/checks/github/GitHubChecksAction.java
@@ -1,0 +1,39 @@
+package io.jenkins.plugins.checks.github;
+
+import hudson.model.InvisibleAction;
+import io.jenkins.plugins.checks.api.ChecksConclusion;
+
+public class GitHubChecksAction extends InvisibleAction {
+
+    private final long id;
+    private final String name;
+    private final ChecksConclusion conclusion;
+
+    public GitHubChecksAction(long id, String name, ChecksConclusion conclusion) {
+        this.id = id;
+        this.name = name;
+        this.conclusion = conclusion;
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public ChecksConclusion getConclusion() {
+        return conclusion;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) { return false; }
+        if (obj == this) { return true; }
+        if (obj.getClass() != getClass()) {
+            return false;
+        }
+        return this.id == ((GitHubChecksAction) obj).id;
+    }
+}

--- a/src/main/java/io/jenkins/plugins/checks/github/GitHubChecksAction.java
+++ b/src/main/java/io/jenkins/plugins/checks/github/GitHubChecksAction.java
@@ -3,6 +3,8 @@ package io.jenkins.plugins.checks.github;
 import hudson.model.InvisibleAction;
 import io.jenkins.plugins.checks.api.ChecksConclusion;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * An invisible action to track the state of GitHub Checks so that the publisher can update existing checks by the
  * same name, and report back to the checks api the state of a named check (without having to go and check GitHub
@@ -25,8 +27,8 @@ public class GitHubChecksAction extends InvisibleAction {
     public GitHubChecksAction(final long id, final String name, final ChecksConclusion conclusion) {
         super();
         this.id = id;
-        this.name = name;
-        this.conclusion = conclusion;
+        this.name = requireNonNull(name);
+        this.conclusion = requireNonNull(conclusion);
     }
 
     public long getId() {
@@ -42,7 +44,7 @@ public class GitHubChecksAction extends InvisibleAction {
     }
 
     public void setConclusion(final ChecksConclusion conclusion) {
-        this.conclusion = conclusion;
+        this.conclusion = requireNonNull(conclusion);
     }
 
 }

--- a/src/main/java/io/jenkins/plugins/checks/github/GitHubChecksAction.java
+++ b/src/main/java/io/jenkins/plugins/checks/github/GitHubChecksAction.java
@@ -3,6 +3,11 @@ package io.jenkins.plugins.checks.github;
 import hudson.model.InvisibleAction;
 import io.jenkins.plugins.checks.api.ChecksConclusion;
 
+/**
+ * An invisible action to track the state of GitHub Checks so that the publisher can update existing checks by the
+ * same name, and report back to the checks api the state of a named check (without having to go and check GitHub
+ * each time).
+ */
 @SuppressWarnings("PMD.DataClass")
 public class GitHubChecksAction extends InvisibleAction {
 
@@ -10,6 +15,13 @@ public class GitHubChecksAction extends InvisibleAction {
     private final String name;
     private ChecksConclusion conclusion;
 
+    /**
+     * Construct a {@link GitHubChecksAction} with the given details.
+     *
+     * @param id the id of the check run as reported by GitHub
+     * @param name the name of the check
+     * @param conclusion the most recent {@link ChecksConclusion} associated with this check
+     */
     public GitHubChecksAction(final long id, final String name, final ChecksConclusion conclusion) {
         super();
         this.id = id;

--- a/src/main/java/io/jenkins/plugins/checks/github/GitHubChecksAction.java
+++ b/src/main/java/io/jenkins/plugins/checks/github/GitHubChecksAction.java
@@ -7,7 +7,7 @@ public class GitHubChecksAction extends InvisibleAction {
 
     private final long id;
     private final String name;
-    private final ChecksConclusion conclusion;
+    private ChecksConclusion conclusion;
 
     public GitHubChecksAction(long id, String name, ChecksConclusion conclusion) {
         this.id = id;
@@ -27,13 +27,8 @@ public class GitHubChecksAction extends InvisibleAction {
         return conclusion;
     }
 
-    @Override
-    public boolean equals(Object obj) {
-        if (obj == null) { return false; }
-        if (obj == this) { return true; }
-        if (obj.getClass() != getClass()) {
-            return false;
-        }
-        return this.id == ((GitHubChecksAction) obj).id;
+    public void setConclusion(ChecksConclusion conclusion) {
+        this.conclusion = conclusion;
     }
+
 }

--- a/src/main/java/io/jenkins/plugins/checks/github/GitHubChecksAction.java
+++ b/src/main/java/io/jenkins/plugins/checks/github/GitHubChecksAction.java
@@ -1,7 +1,6 @@
 package io.jenkins.plugins.checks.github;
 
 import hudson.model.InvisibleAction;
-import io.jenkins.plugins.checks.api.ChecksConclusion;
 
 import static java.util.Objects.requireNonNull;
 
@@ -15,20 +14,17 @@ public class GitHubChecksAction extends InvisibleAction {
 
     private final long id;
     private final String name;
-    private ChecksConclusion conclusion;
 
     /**
      * Construct a {@link GitHubChecksAction} with the given details.
      *
      * @param id the id of the check run as reported by GitHub
      * @param name the name of the check
-     * @param conclusion the most recent {@link ChecksConclusion} associated with this check
      */
-    public GitHubChecksAction(final long id, final String name, final ChecksConclusion conclusion) {
+    public GitHubChecksAction(final long id, final String name) {
         super();
         this.id = id;
         this.name = requireNonNull(name);
-        this.conclusion = requireNonNull(conclusion);
     }
 
     public long getId() {
@@ -37,14 +33,6 @@ public class GitHubChecksAction extends InvisibleAction {
 
     public String getName() {
         return name;
-    }
-
-    public ChecksConclusion getConclusion() {
-        return conclusion;
-    }
-
-    public void setConclusion(final ChecksConclusion conclusion) {
-        this.conclusion = requireNonNull(conclusion);
     }
 
 }

--- a/src/main/java/io/jenkins/plugins/checks/github/GitHubChecksContext.java
+++ b/src/main/java/io/jenkins/plugins/checks/github/GitHubChecksContext.java
@@ -128,6 +128,11 @@ abstract class GitHubChecksContext {
     }
 
     void updateAction(final long id, final String name, final ChecksConclusion conclusion) {
-        job.addOrReplaceAction(new GitHubChecksAction(id, name, conclusion));
+        Optional<GitHubChecksAction> action = getAction(name);
+        if (action.isPresent()) {
+            action.get().setConclusion(conclusion);
+        } else {
+            job.addAction(new GitHubChecksAction(id, name, conclusion));
+        }
     }
 }

--- a/src/main/java/io/jenkins/plugins/checks/github/GitHubChecksContext.java
+++ b/src/main/java/io/jenkins/plugins/checks/github/GitHubChecksContext.java
@@ -114,12 +114,10 @@ abstract class GitHubChecksContext {
         return getAction(name).map(GitHubChecksAction::getId);
     }
 
-    // New API method
-    ChecksConclusion getConclusion(final String name) {
+    public ChecksConclusion getConclusion(final String name) {
         return getAction(name).map(GitHubChecksAction::getConclusion).orElse(ChecksConclusion.NONE);
     }
 
-    // Implementation using invisible actions
     private Optional<GitHubChecksAction> getAction(final String name) {
         return job.getActions(GitHubChecksAction.class)
                 .stream()

--- a/src/main/java/io/jenkins/plugins/checks/github/GitHubChecksContext.java
+++ b/src/main/java/io/jenkins/plugins/checks/github/GitHubChecksContext.java
@@ -110,7 +110,7 @@ abstract class GitHubChecksContext {
         return getScmFacade().findGitHubAppCredentials(getJob(), credentialsId);
     }
 
-    Optional<Long> getId(final String name) {
+    public Optional<Long> getId(final String name) {
         return getAction(name).map(GitHubChecksAction::getId);
     }
 
@@ -125,7 +125,7 @@ abstract class GitHubChecksContext {
                 .findFirst();
     }
 
-    void updateAction(final long id, final String name, final ChecksConclusion conclusion) {
+    void addOrUpdateAction(final long id, final String name, final ChecksConclusion conclusion) {
         Optional<GitHubChecksAction> action = getAction(name);
         if (action.isPresent()) {
             action.get().setConclusion(conclusion);

--- a/src/main/java/io/jenkins/plugins/checks/github/GitHubChecksContext.java
+++ b/src/main/java/io/jenkins/plugins/checks/github/GitHubChecksContext.java
@@ -131,7 +131,8 @@ abstract class GitHubChecksContext {
         Optional<GitHubChecksAction> action = getAction(name);
         if (action.isPresent()) {
             action.get().setConclusion(conclusion);
-        } else {
+        }
+        else {
             job.addAction(new GitHubChecksAction(id, name, conclusion));
         }
     }

--- a/src/main/java/io/jenkins/plugins/checks/github/GitHubChecksContext.java
+++ b/src/main/java/io/jenkins/plugins/checks/github/GitHubChecksContext.java
@@ -6,9 +6,7 @@ import hudson.model.Job;
 import io.jenkins.plugins.checks.api.ChecksConclusion;
 import org.apache.commons.lang3.StringUtils;
 import org.jenkinsci.plugins.github_branch_source.GitHubAppCredentials;
-import org.kohsuke.github.GitHub;
 
-import java.io.IOException;
 import java.util.Optional;
 
 /**
@@ -127,18 +125,6 @@ abstract class GitHubChecksContext {
                 .stream()
                 .filter(a -> a.getName().equals(name))
                 .findFirst();
-    }
-
-    // Implementation fetching info on request
-    private Optional<GitHubChecksAction> getAction(final GitHub gitHub, final String name) throws IOException {
-        return gitHub.getRepository(getRepository())
-                .getCheckRuns(getHeadSha())
-                .toList()
-                .stream()
-                .filter(r -> r.getName() == name)
-                .findFirst()
-                .map(r -> new GitHubChecksAction(r.getId(), r.getName(), ChecksConclusion.NONE)); // obviously replace with logic to get ChecksConclusion from string
-
     }
 
     void updateAction(final long id, final String name, final ChecksConclusion conclusion) {

--- a/src/main/java/io/jenkins/plugins/checks/github/GitHubChecksContext.java
+++ b/src/main/java/io/jenkins/plugins/checks/github/GitHubChecksContext.java
@@ -3,7 +3,6 @@ package io.jenkins.plugins.checks.github;
 import edu.hm.hafner.util.FilteredLog;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import hudson.model.Job;
-import io.jenkins.plugins.checks.api.ChecksConclusion;
 import org.apache.commons.lang3.StringUtils;
 import org.jenkinsci.plugins.github_branch_source.GitHubAppCredentials;
 
@@ -114,9 +113,6 @@ abstract class GitHubChecksContext {
         return getAction(name).map(GitHubChecksAction::getId);
     }
 
-    public ChecksConclusion getConclusion(final String name) {
-        return getAction(name).map(GitHubChecksAction::getConclusion).orElse(ChecksConclusion.NONE);
-    }
 
     private Optional<GitHubChecksAction> getAction(final String name) {
         return job.getActions(GitHubChecksAction.class)
@@ -125,13 +121,10 @@ abstract class GitHubChecksContext {
                 .findFirst();
     }
 
-    void addOrUpdateAction(final long id, final String name, final ChecksConclusion conclusion) {
+    void addActionIfMissing(final long id, final String name) {
         Optional<GitHubChecksAction> action = getAction(name);
-        if (action.isPresent()) {
-            action.get().setConclusion(conclusion);
-        }
-        else {
-            job.addAction(new GitHubChecksAction(id, name, conclusion));
+        if (!action.isPresent()) {
+            job.addAction(new GitHubChecksAction(id, name));
         }
     }
 }

--- a/src/main/java/io/jenkins/plugins/checks/github/GitHubChecksPublisher.java
+++ b/src/main/java/io/jenkins/plugins/checks/github/GitHubChecksPublisher.java
@@ -1,6 +1,7 @@
 package io.jenkins.plugins.checks.github;
 
 import edu.hm.hafner.util.VisibleForTesting;
+import io.jenkins.plugins.checks.api.ChecksConclusion;
 import io.jenkins.plugins.checks.api.ChecksDetails;
 import io.jenkins.plugins.checks.api.ChecksPublisher;
 import io.jenkins.plugins.util.PluginLogger;
@@ -125,5 +126,10 @@ public class GitHubChecksPublisher extends ChecksPublisher {
         details.getActions().forEach(builder::add);
 
         return builder;
+    }
+
+    // New API method
+    ChecksConclusion getConclusion(final String name) {
+        return context.getConclusion(name);
     }
 }

--- a/src/main/java/io/jenkins/plugins/checks/github/GitHubChecksPublisher.java
+++ b/src/main/java/io/jenkins/plugins/checks/github/GitHubChecksPublisher.java
@@ -70,7 +70,8 @@ public class GitHubChecksPublisher extends ChecksPublisher {
 
             if (existingId.isPresent()) {
                 run = createUpdater(gitHub, gitHubDetails, existingId.get()).create();
-            } else {
+            }
+            else {
                 run = createBuilder(gitHub, gitHubDetails).create();
             }
 
@@ -109,7 +110,7 @@ public class GitHubChecksPublisher extends ChecksPublisher {
         return updateBuilder(builder, details);
     }
 
-    private GHCheckRunBuilder updateBuilder(final GHCheckRunBuilder builder, GitHubChecksDetails details) {
+    private GHCheckRunBuilder updateBuilder(final GHCheckRunBuilder builder, final GitHubChecksDetails details) {
         builder
                 .withStatus(details.getStatus())
                 .withExternalID(context.getJob().getFullName())

--- a/src/main/java/io/jenkins/plugins/checks/github/GitHubChecksPublisher.java
+++ b/src/main/java/io/jenkins/plugins/checks/github/GitHubChecksPublisher.java
@@ -1,7 +1,6 @@
 package io.jenkins.plugins.checks.github;
 
 import edu.hm.hafner.util.VisibleForTesting;
-import io.jenkins.plugins.checks.api.ChecksConclusion;
 import io.jenkins.plugins.checks.api.ChecksDetails;
 import io.jenkins.plugins.checks.api.ChecksPublisher;
 import io.jenkins.plugins.util.PluginLogger;
@@ -76,7 +75,7 @@ public class GitHubChecksPublisher extends ChecksPublisher {
                 run = getCreator(gitHub, gitHubDetails).create();
             }
 
-            context.addOrUpdateAction(run.getId(), gitHubDetails.getName(), details.getConclusion());
+            context.addActionIfMissing(run.getId(), gitHubDetails.getName());
 
             buildLogger.log("GitHub check (name: %s, status: %s) has been published.", gitHubDetails.getName(),
                     gitHubDetails.getStatus());
@@ -128,8 +127,4 @@ public class GitHubChecksPublisher extends ChecksPublisher {
         return builder;
     }
 
-    // New API method
-    ChecksConclusion getConclusion(final String name) {
-        return context.getConclusion(name);
-    }
 }

--- a/src/test/java/io/jenkins/plugins/checks/github/GitHubChecksPublisherITest.java
+++ b/src/test/java/io/jenkins/plugins/checks/github/GitHubChecksPublisherITest.java
@@ -60,7 +60,7 @@ import static org.mockito.Mockito.*;
  * Tests if the {@link GitHubChecksPublisher} actually sends out the requests to GitHub in order to publish the check
  * runs.
  */
-@SuppressWarnings({"PMD.ExcessiveImports", "checkstyle:ClassDataAbstractionCoupling", "rawtypes"})
+@SuppressWarnings({"PMD.ExcessiveImports", "checkstyle:ClassDataAbstractionCoupling", "rawtypes", "checkstyle:ClassFanOutComplexity"})
 public class GitHubChecksPublisherITest extends IntegrationTestWithJenkinsPerTest {
 
     /**
@@ -179,7 +179,10 @@ public class GitHubChecksPublisherITest extends IntegrationTestWithJenkinsPerTes
     }
 
     /**
-     * We can't mock the id field on GHObjects thanks to WithBridgeMethods. So, create a stub GHCheckRun with the id we want.
+     * We can't mock the id field on {@link org.kohsuke.github.GHObject}s thanks to {@link com.infradna.tool.bridge_method_injector.WithBridgeMethods}.
+     * So, create a stub GHCheckRun with the id we want.
+     * @param id id of check run to spoof
+     * @return Stubbed {@link GHCheckRun} with only {@link GHCheckRun#id} set
      */
     private GHCheckRun createStubCheckRun(long id) throws Exception {
         ObjectMapper mapper = new ObjectMapper();
@@ -193,6 +196,9 @@ public class GitHubChecksPublisherITest extends IntegrationTestWithJenkinsPerTes
         return reader.readValue(String.format("{\"id\": %d}", id));
     }
 
+    /**
+     * Test that publishing a second check with the same name will update rather than overwrite the existing check.
+     */
     @Test
     public void testChecksPublisherUpdatesCorrectly() throws Exception {
         GitHub gitHub = mock(GitHub.class);

--- a/src/test/java/io/jenkins/plugins/checks/github/GitHubChecksPublisherITest.java
+++ b/src/test/java/io/jenkins/plugins/checks/github/GitHubChecksPublisherITest.java
@@ -237,8 +237,6 @@ public class GitHubChecksPublisherITest extends IntegrationTestWithJenkinsPerTes
 
             assertThat(context.getId(checksName1)).isNotPresent();
             assertThat(context.getId(checksName2)).isNotPresent();
-            assertThat(context.getConclusion(checksName1)).isEqualTo(ChecksConclusion.NONE);
-            assertThat(context.getConclusion(checksName2)).isEqualTo(ChecksConclusion.NONE);
 
             publisher.publish(details1);
 
@@ -248,8 +246,6 @@ public class GitHubChecksPublisherITest extends IntegrationTestWithJenkinsPerTes
 
             assertThat(context.getId(checksName1)).isPresent().get().isEqualTo(checksId1);
             assertThat(context.getId(checksName2)).isNotPresent();
-            assertThat(context.getConclusion(checksName1)).isEqualTo(ChecksConclusion.NONE);
-            assertThat(context.getConclusion(checksName2)).isEqualTo(ChecksConclusion.NONE);
 
             ChecksDetails details2 = new ChecksDetailsBuilder()
                     .withName(checksName2)
@@ -265,8 +261,6 @@ public class GitHubChecksPublisherITest extends IntegrationTestWithJenkinsPerTes
 
             assertThat(context.getId(checksName1)).isPresent().get().isEqualTo(checksId1);
             assertThat(context.getId(checksName2)).isPresent().get().isEqualTo(checksId2);
-            assertThat(context.getConclusion(checksName1)).isEqualTo(ChecksConclusion.NONE);
-            assertThat(context.getConclusion(checksName2)).isEqualTo(ChecksConclusion.SUCCESS);
 
             ChecksDetails updateDetails1 = new ChecksDetailsBuilder()
                     .withName(checksName1)
@@ -282,8 +276,6 @@ public class GitHubChecksPublisherITest extends IntegrationTestWithJenkinsPerTes
 
             assertThat(context.getId(checksName1)).isPresent().get().isEqualTo(checksId1);
             assertThat(context.getId(checksName2)).isPresent().get().isEqualTo(checksId2);
-            assertThat(context.getConclusion(checksName1)).isEqualTo(ChecksConclusion.FAILURE);
-            assertThat(context.getConclusion(checksName2)).isEqualTo(ChecksConclusion.SUCCESS);
 
         }
     }


### PR DESCRIPTION
@XiongKezhi this is an implementation to support `withChecks` in https://github.com/jenkinsci/checks-api-plugin/pull/49 as an example of what I was describing in my comment there. I've provided two possible implementations, one which uses `InvisibleActions` to track state, and one which looks up the info from GitHub on demand.

This also depends github-branch-source plugin pulling in the new github-api.