### PR TITLE
Migrate to use new API for status checks properties

### DIFF
--- a/src/main/java/io/jenkins/plugins/checks/github/status/GitHubStatusChecksProperties.java
+++ b/src/main/java/io/jenkins/plugins/checks/github/status/GitHubStatusChecksProperties.java
@@ -5,7 +5,7 @@ import hudson.Extension;
 import hudson.model.Job;
 import hudson.plugins.git.GitSCM;
 import io.jenkins.plugins.checks.github.SCMFacade;
-import io.jenkins.plugins.checks.status.StatusChecksProperties;
+import io.jenkins.plugins.checks.status.AbstractStatusChecksProperties;
 import jenkins.plugins.git.GitSCMSource;
 import org.jenkinsci.plugins.github_branch_source.GitHubSCMSource;
 
@@ -13,11 +13,11 @@ import java.util.Optional;
 import java.util.stream.Stream;
 
 /**
- * Implementing {@link StatusChecksProperties} to retrieve properties from jobs with
- * {@link GitHubSCMSource}, {@link GitSCM}, or {@link GitSCMSource}.
+ * Implementing {@link io.jenkins.plugins.checks.status.AbstractStatusChecksProperties} to retrieve properties
+ * from jobs with {@link GitHubSCMSource}, {@link GitSCM}, or {@link GitSCMSource}.
  */
 @Extension
-public class GitHubStatusChecksProperties implements StatusChecksProperties {
+public class GitHubStatusChecksProperties extends AbstractStatusChecksProperties {
     private final SCMFacade scmFacade;
 
     /**
@@ -29,6 +29,8 @@ public class GitHubStatusChecksProperties implements StatusChecksProperties {
 
     @VisibleForTesting
     GitHubStatusChecksProperties(final SCMFacade facade) {
+        super();
+
         this.scmFacade = facade;
     }
 
@@ -43,7 +45,7 @@ public class GitHubStatusChecksProperties implements StatusChecksProperties {
     }
 
     @Override
-    public boolean isSkip(final Job<?, ?> job) {
+    public boolean isSkipped(final Job<?, ?> job) {
         return getConfigurations(job).orElse(new DefaultGitHubStatusChecksConfigurations()).isSkip();
     }
 

--- a/src/test/java/io/jenkins/plugins/checks/github/status/GitHubStatusChecksPropertiesTest.java
+++ b/src/test/java/io/jenkins/plugins/checks/github/status/GitHubStatusChecksPropertiesTest.java
@@ -91,7 +91,7 @@ class GitHubStatusChecksPropertiesTest {
                                                 final boolean isApplicable, final String name, final boolean isSkip) {
         assertThat(properties.isApplicable(job)).isEqualTo(isApplicable);
         assertThat(properties.getName(job)).isEqualTo(name);
-        assertThat(properties.isSkip(job)).isEqualTo(isSkip);
+        assertThat(properties.isSkipped(job)).isEqualTo(isSkip);
     }
 }
 


### PR DESCRIPTION
Adapt the new API `AbstractStatusChecksProperties` from https://github.com/jenkinsci/checks-api-plugin/pull/52.