### PR TITLE
Support arbitrary enterprise url in GitSCMContext.

### DIFF
--- a/src/main/java/io/jenkins/plugins/checks/github/GitSCMChecksContext.java
+++ b/src/main/java/io/jenkins/plugins/checks/github/GitSCMChecksContext.java
@@ -121,13 +121,6 @@ class GitSCMChecksContext extends GitHubChecksContext {
             return false;
         }
 
-        String remoteUrl = getRemoteUrl();
-        if (!isValidUrl(remoteUrl)) {
-            logger.logError("No supported GitSCM repository URL: " + remoteUrl);
-
-            return false;
-        }
-
         if (!hasValidCredentials(logger)) {
             return false;
         }
@@ -142,10 +135,5 @@ class GitSCMChecksContext extends GitHubChecksContext {
         logger.logInfo("Using GitSCM repository '%s' for GitHub checks", repository);
 
         return true;
-    }
-
-    private boolean isValidUrl(@CheckForNull final String remoteUrl) {
-        return StringUtils.startsWith(remoteUrl, GIT_PROTOCOL)
-                || StringUtils.startsWith(remoteUrl, HTTPS_PROTOCOL);
     }
 }


### PR DESCRIPTION
Context: https://github.com/jenkinsci/github-checks-plugin/issues/49#issuecomment-752797605 

The enterprise URL is arbitrary but currently, we check the remote URL if it starts with "git@github.com:" or "https://github.com/". The purpose to check it is that we want to make sure that the remote repository is GitHub since for a Git SCM project (e.g. freestyle project) the remote repository can be anything using git besides GitHub.

However, while we are trying to apply the context, we also check if the GitHub app credentials are valid: https://github.com/jenkinsci/github-checks-plugin/blob/8777ccffb459db6ec042c6aab8dd2a11af66f1dc/src/main/java/io/jenkins/plugins/checks/github/GitSCMChecksContext.java#L131 
Thus, the url check seems redundant and checking the api url of the credentials seems useless as well since the api url simply follows https pattern: https://docs.github.com/en/rest/reference/enterprise-admin#endpoint-urls.