### PR TITLE
Resolve repository from enterprise GitHub url in http and git protocol scheme

### DIFF
--- a/src/main/java/io/jenkins/plugins/checks/github/GitSCMChecksContext.java
+++ b/src/main/java/io/jenkins/plugins/checks/github/GitSCMChecksContext.java
@@ -75,10 +75,6 @@ class GitSCMChecksContext extends GitHubChecksContext {
     @Override
     public String getRepository() {
         String repositoryUrl = getUserRemoteConfig().getUrl();
-        if (repositoryUrl == null) {
-            return StringUtils.EMPTY;
-        }
-
         if (StringUtils.isBlank(repositoryUrl)) {
             return StringUtils.EMPTY;
         }

--- a/src/main/java/io/jenkins/plugins/checks/github/GitSCMChecksContext.java
+++ b/src/main/java/io/jenkins/plugins/checks/github/GitSCMChecksContext.java
@@ -1,6 +1,7 @@
 package io.jenkins.plugins.checks.github;
 
 import edu.hm.hafner.util.FilteredLog;
+import edu.hm.hafner.util.VisibleForTesting;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import hudson.model.Run;
 import hudson.model.TaskListener;
@@ -74,7 +75,16 @@ class GitSCMChecksContext extends GitHubChecksContext {
 
     @Override
     public String getRepository() {
-        String repositoryUrl = getUserRemoteConfig().getUrl();
+        String repositoryURL = getUserRemoteConfig().getUrl();
+        if (repositoryURL == null) {
+            return StringUtils.EMPTY;
+        }
+
+        return getRepository(repositoryURL);
+    }
+
+    @VisibleForTesting
+    String getRepository(final String repositoryUrl) {
         if (StringUtils.isBlank(repositoryUrl)) {
             return StringUtils.EMPTY;
         }

--- a/src/test/java/io/jenkins/plugins/checks/github/GitSCMChecksContextITest.java
+++ b/src/test/java/io/jenkins/plugins/checks/github/GitSCMChecksContextITest.java
@@ -16,18 +16,17 @@ import hudson.plugins.git.BranchSpec;
 import hudson.plugins.git.GitSCM;
 
 /**
- * Integration tests for {@link GitSCMChecksContextTest}.
+ * Integration tests for {@link GitSCMChecksContext}.
  */
 public class GitSCMChecksContextITest extends IntegrationTestWithJenkinsPerSuite {
     private static final String EXISTING_HASH = "4ecc8623b06d99d5f029b66927438554fdd6a467";
     private static final String HTTP_URL = "https://github.com/jenkinsci/github-checks-plugin.git";
-    private static final String GIT_URL = "git@github.com:jenkinsci/github-checks-plugin.git";
     private static final String CREDENTIALS_ID = "credentials";
     private static final String URL_NAME = "url";
 
     /**
      * Creates a FreeStyle job that uses {@link hudson.plugins.git.GitSCM} and runs a successful build.
-     * Then this build is used to create a new {@link GitSCMChecksContextTest}. So the build actually is not publishing
+     * Then this build is used to create a new {@link GitSCMChecksContext}. So the build actually is not publishing
      * the checks we just ensure that we can create the context with the successful build (otherwise we would need
      * Wiremock to handle the requests to GitHub).
      */
@@ -52,43 +51,28 @@ public class GitSCMChecksContextITest extends IntegrationTestWithJenkinsPerSuite
 
     /**
      * Creates a pipeline that uses {@link hudson.plugins.git.GitSCM} and runs a successful build.
-     * Then this build is used to create a new {@link GitSCMChecksContextTest}.
-     * The repository url used in this test is in http scheme.
+     * Then this build is used to create a new {@link GitSCMChecksContext}. 
      */
     @Test 
-    public void shouldRetrieveContextFromPipelineWithHttpProtocolURL() {
-        shouldRetrieveContextFromPipeline(HTTP_URL);
-    }
-
-    /**
-     * Creates a pipeline that uses {@link hudson.plugins.git.GitSCM} and runs a successful build.
-     * Then this build is used to create a new {@link GitSCMChecksContextTest}.
-     * The repository url used in this test is in git protocol scheme.
-     */
-    @Test
-    public void shouldRetrieveContextFromPipelineWithGitProtocol() {
-        shouldRetrieveContextFromPipeline(GIT_URL);
-    }
-
-    private void shouldRetrieveContextFromPipeline(final String url) {
+    public void shouldRetrieveContextFromPipeline() {
         WorkflowJob job = createPipeline();
-
-        job.setDefinition(new CpsFlowDefinition("node {\n"
-                + "  stage ('Checkout') {\n"
+        
+        job.setDefinition(new CpsFlowDefinition("node {\n" 
+                + "  stage ('Checkout') {\n" 
                 + "    checkout scm: ([\n"
                 + "                    $class: 'GitSCM',\n"
-                + "                    userRemoteConfigs: [[credentialsId: '" + CREDENTIALS_ID + "', url: '" + url + "']],\n"
+                + "                    userRemoteConfigs: [[credentialsId: '" + CREDENTIALS_ID + "', url: '" + HTTP_URL + "']],\n"
                 + "                    branches: [[name: '" + EXISTING_HASH + "']]\n"
                 + "            ])"
-                + "  }\n"
+                + "  }\n" 
                 + "}\n", true));
-
+        
         Run<?, ?> run = buildSuccessfully(job);
 
         GitSCMChecksContext gitSCMChecksContext = new GitSCMChecksContext(run, URL_NAME);
 
         assertThat(gitSCMChecksContext.getRepository()).isEqualTo("jenkinsci/github-checks-plugin");
         assertThat(gitSCMChecksContext.getCredentialsId()).isEqualTo(CREDENTIALS_ID);
-        assertThat(gitSCMChecksContext.getHeadSha()).isEqualTo(EXISTING_HASH);
+        assertThat(gitSCMChecksContext.getHeadSha()).isEqualTo(EXISTING_HASH); 
     }
 }

--- a/src/test/java/io/jenkins/plugins/checks/github/GitSCMChecksContextITest.java
+++ b/src/test/java/io/jenkins/plugins/checks/github/GitSCMChecksContextITest.java
@@ -16,17 +16,18 @@ import hudson.plugins.git.BranchSpec;
 import hudson.plugins.git.GitSCM;
 
 /**
- * Integration tests for {@link GitSCMChecksContext}.
+ * Integration tests for {@link GitSCMChecksContextTest}.
  */
 public class GitSCMChecksContextITest extends IntegrationTestWithJenkinsPerSuite {
     private static final String EXISTING_HASH = "4ecc8623b06d99d5f029b66927438554fdd6a467";
     private static final String HTTP_URL = "https://github.com/jenkinsci/github-checks-plugin.git";
+    private static final String GIT_URL = "git@github.com:jenkinsci/github-checks-plugin.git";
     private static final String CREDENTIALS_ID = "credentials";
     private static final String URL_NAME = "url";
 
     /**
      * Creates a FreeStyle job that uses {@link hudson.plugins.git.GitSCM} and runs a successful build.
-     * Then this build is used to create a new {@link GitSCMChecksContext}. So the build actually is not publishing
+     * Then this build is used to create a new {@link GitSCMChecksContextTest}. So the build actually is not publishing
      * the checks we just ensure that we can create the context with the successful build (otherwise we would need
      * Wiremock to handle the requests to GitHub).
      */
@@ -51,28 +52,43 @@ public class GitSCMChecksContextITest extends IntegrationTestWithJenkinsPerSuite
 
     /**
      * Creates a pipeline that uses {@link hudson.plugins.git.GitSCM} and runs a successful build.
-     * Then this build is used to create a new {@link GitSCMChecksContext}. 
+     * Then this build is used to create a new {@link GitSCMChecksContextTest}.
+     * The repository url used in this test is in http scheme.
      */
     @Test 
-    public void shouldRetrieveContextFromPipeline() {
+    public void shouldRetrieveContextFromPipelineWithHttpProtocolURL() {
+        shouldRetrieveContextFromPipeline(HTTP_URL);
+    }
+
+    /**
+     * Creates a pipeline that uses {@link hudson.plugins.git.GitSCM} and runs a successful build.
+     * Then this build is used to create a new {@link GitSCMChecksContextTest}.
+     * The repository url used in this test is in git protocol scheme.
+     */
+    @Test
+    public void shouldRetrieveContextFromPipelineWithGitProtocol() {
+        shouldRetrieveContextFromPipeline(GIT_URL);
+    }
+
+    private void shouldRetrieveContextFromPipeline(final String url) {
         WorkflowJob job = createPipeline();
-        
-        job.setDefinition(new CpsFlowDefinition("node {\n" 
-                + "  stage ('Checkout') {\n" 
+
+        job.setDefinition(new CpsFlowDefinition("node {\n"
+                + "  stage ('Checkout') {\n"
                 + "    checkout scm: ([\n"
                 + "                    $class: 'GitSCM',\n"
-                + "                    userRemoteConfigs: [[credentialsId: '" + CREDENTIALS_ID + "', url: '" + HTTP_URL + "']],\n"
+                + "                    userRemoteConfigs: [[credentialsId: '" + CREDENTIALS_ID + "', url: '" + url + "']],\n"
                 + "                    branches: [[name: '" + EXISTING_HASH + "']]\n"
                 + "            ])"
-                + "  }\n" 
+                + "  }\n"
                 + "}\n", true));
-        
+
         Run<?, ?> run = buildSuccessfully(job);
 
         GitSCMChecksContext gitSCMChecksContext = new GitSCMChecksContext(run, URL_NAME);
 
         assertThat(gitSCMChecksContext.getRepository()).isEqualTo("jenkinsci/github-checks-plugin");
         assertThat(gitSCMChecksContext.getCredentialsId()).isEqualTo(CREDENTIALS_ID);
-        assertThat(gitSCMChecksContext.getHeadSha()).isEqualTo(EXISTING_HASH); 
+        assertThat(gitSCMChecksContext.getHeadSha()).isEqualTo(EXISTING_HASH);
     }
 }

--- a/src/test/java/io/jenkins/plugins/checks/github/GitSCMChecksContextTest.java
+++ b/src/test/java/io/jenkins/plugins/checks/github/GitSCMChecksContextTest.java
@@ -1,27 +1,14 @@
 package io.jenkins.plugins.checks.github;
 
 import hudson.model.Run;
-import hudson.plugins.git.GitSCM;
-import hudson.plugins.git.UserRemoteConfig;
 import org.junit.jupiter.api.Test;
-
-import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 class GitSCMChecksContextTest {
     @Test
     public void shouldGetRepository() {
-        Run run = mock(Run.class);
-        GitSCM scm = mock(GitSCM.class);
-        UserRemoteConfig config = mock(UserRemoteConfig.class);
-        SCMFacade facade = mock(SCMFacade.class);
-
-        when(facade.findGitSCM(run)).thenReturn(Optional.of(scm));
-        when(facade.getUserRemoteConfig(scm)).thenReturn(config);
-
         for (String url : new String[]{
                 "git@197.168.2.0:jenkinsci/github-checks-plugin",
                 "git@localhost:jenkinsci/github-checks-plugin",
@@ -29,8 +16,7 @@ class GitSCMChecksContextTest {
                 "http://github.com/jenkinsci/github-checks-plugin.git",
                 "https://github.com/jenkinsci/github-checks-plugin.git"
         }) {
-            when(config.getUrl()).thenReturn(url);
-            assertThat(new GitSCMChecksContext(run, "", facade).getRepository())
+            assertThat(new GitSCMChecksContext(mock(Run.class), "").getRepository(url))
                     .isEqualTo("jenkinsci/github-checks-plugin");
         }
     }

--- a/src/test/java/io/jenkins/plugins/checks/github/GitSCMChecksContextTest.java
+++ b/src/test/java/io/jenkins/plugins/checks/github/GitSCMChecksContextTest.java
@@ -25,12 +25,12 @@ class GitSCMChecksContextTest {
         for (String url : new String[]{
                 "git@197.168.2.0:jenkinsci/github-checks-plugin",
                 "git@localhost:jenkinsci/github-checks-plugin",
+                "git@github.com:jenkinsci/github-checks-plugin",
                 "http://github.com/jenkinsci/github-checks-plugin.git",
                 "https://github.com/jenkinsci/github-checks-plugin.git"
         }) {
             when(config.getUrl()).thenReturn(url);
-            assertThat(new GitSCMChecksContext(run, "", facade)
-                    .getRepository())
+            assertThat(new GitSCMChecksContext(run, "", facade).getRepository())
                     .isEqualTo("jenkinsci/github-checks-plugin");
         }
     }

--- a/src/test/java/io/jenkins/plugins/checks/github/GitSCMChecksContextTest.java
+++ b/src/test/java/io/jenkins/plugins/checks/github/GitSCMChecksContextTest.java
@@ -1,0 +1,37 @@
+package io.jenkins.plugins.checks.github;
+
+import hudson.model.Run;
+import hudson.plugins.git.GitSCM;
+import hudson.plugins.git.UserRemoteConfig;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class GitSCMChecksContextTest {
+    @Test
+    public void shouldGetRepository() {
+        Run run = mock(Run.class);
+        GitSCM scm = mock(GitSCM.class);
+        UserRemoteConfig config = mock(UserRemoteConfig.class);
+        SCMFacade facade = mock(SCMFacade.class);
+
+        when(facade.findGitSCM(run)).thenReturn(Optional.of(scm));
+        when(facade.getUserRemoteConfig(scm)).thenReturn(config);
+
+        for (String url : new String[]{
+                "git@197.168.2.0:jenkinsci/github-checks-plugin",
+                "git@localhost:jenkinsci/github-checks-plugin",
+                "http://github.com/jenkinsci/github-checks-plugin.git",
+                "https://github.com/jenkinsci/github-checks-plugin.git"
+        }) {
+            when(config.getUrl()).thenReturn(url);
+            assertThat(new GitSCMChecksContext(run, "", facade)
+                    .getRepository())
+                    .isEqualTo("jenkinsci/github-checks-plugin");
+        }
+    }
+}


### PR DESCRIPTION
The repository full name resolving code refers to https://github.com/jenkinsci/github-branch-source-plugin/blob/1fd2d6f3e1a607f075aed3895420cd50f06ca8d4/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubRepositoryInfo.java#L80

context: https://github.com/jenkinsci/github-checks-plugin/issues/49#issuecomment-763910554