### PR TITLE
Disable notifications compatibility with other plugins

### DIFF
--- a/src/main/java/io/jenkins/plugins/checks/github/status/GitHubSCMSourceStatusChecksTrait.java
+++ b/src/main/java/io/jenkins/plugins/checks/github/status/GitHubSCMSourceStatusChecksTrait.java
@@ -90,7 +90,7 @@ public class GitHubSCMSourceStatusChecksTrait extends SCMSourceTrait implements 
 
     @Override
     protected void decorateContext(final SCMSourceContext<?, ?> context) {
-        if (isSkipNotifications()) {
+        if (isSkipNotifications() && context instanceof GitHubSCMSourceContext) {
             ((GitHubSCMSourceContext)context).withNotificationsDisabled(true);
         }
     }

--- a/src/main/java/io/jenkins/plugins/checks/github/status/GitHubSCMSourceStatusChecksTrait.java
+++ b/src/main/java/io/jenkins/plugins/checks/github/status/GitHubSCMSourceStatusChecksTrait.java
@@ -91,7 +91,10 @@ public class GitHubSCMSourceStatusChecksTrait extends SCMSourceTrait implements 
     @Override
     protected void decorateContext(final SCMSourceContext<?, ?> context) {
         if (context instanceof GitHubSCMSourceContext) {
-            ((GitHubSCMSourceContext) context).withNotificationsDisabled(isSkipNotifications());
+            GitHubSCMSourceContext githubContext = (GitHubSCMSourceContext) context;
+            if (!githubContext.notificationsDisabled()) {
+                githubContext.withNotificationsDisabled(isSkipNotifications());
+            }
         }
     }
 

--- a/src/main/java/io/jenkins/plugins/checks/github/status/GitHubSCMSourceStatusChecksTrait.java
+++ b/src/main/java/io/jenkins/plugins/checks/github/status/GitHubSCMSourceStatusChecksTrait.java
@@ -90,11 +90,8 @@ public class GitHubSCMSourceStatusChecksTrait extends SCMSourceTrait implements 
 
     @Override
     protected void decorateContext(final SCMSourceContext<?, ?> context) {
-        if (context instanceof GitHubSCMSourceContext) {
-            GitHubSCMSourceContext githubContext = (GitHubSCMSourceContext) context;
-            if (!githubContext.notificationsDisabled()) {
-                githubContext.withNotificationsDisabled(isSkipNotifications());
-            }
+        if (isSkipNotifications()) {
+            ((GitHubSCMSourceContext)context).withNotificationsDisabled(true);
         }
     }
 

--- a/src/main/resources/io/jenkins/plugins/checks/github/status/GitHubSCMSourceStatusChecksTrait/help-skipNotifications.html
+++ b/src/main/resources/io/jenkins/plugins/checks/github/status/GitHubSCMSourceStatusChecksTrait/help-skipNotifications.html
@@ -1,0 +1,5 @@
+<div>
+    If this option is checked, the notifications sent by the <a href="https://plugins.jenkins.io/github-branch-source/">GitHub Branch Source Plugin</a>
+    will be disabled. Note that, whether checked or not, this option will only be applied when no other plugins are disabling
+    the notifications.
+</div>

--- a/src/main/resources/io/jenkins/plugins/checks/github/status/GitHubSCMSourceStatusChecksTrait/help-skipNotifications.html
+++ b/src/main/resources/io/jenkins/plugins/checks/github/status/GitHubSCMSourceStatusChecksTrait/help-skipNotifications.html
@@ -1,5 +1,4 @@
 <div>
     If this option is checked, the notifications sent by the <a href="https://plugins.jenkins.io/github-branch-source/">GitHub Branch Source Plugin</a>
-    will be disabled. Note that, whether checked or not, this option will only be applied when no other plugins are disabling
-    the notifications.
+    will be disabled.
 </div>

--- a/src/test/java/io/jenkins/plugins/checks/github/status/GitHubSCMSourceStatusChecksTraitTest.java
+++ b/src/test/java/io/jenkins/plugins/checks/github/status/GitHubSCMSourceStatusChecksTraitTest.java
@@ -1,0 +1,30 @@
+package io.jenkins.plugins.checks.github.status;
+
+import jenkins.scm.api.SCMHeadObserver;
+import jenkins.scm.api.SCMSourceCriteria;
+import org.jenkinsci.plugins.github_branch_source.GitHubSCMSourceContext;
+import org.junit.jupiter.api.Test;
+
+import static io.jenkins.plugins.util.assertions.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class GitHubSCMSourceStatusChecksTraitTest {
+    @Test
+    void shouldOnlyApplyTraitConfigurationsToGitHubBranchSourceNotificationsWhenItsNotDisabled() {
+        GitHubSCMSourceContext context = new GitHubSCMSourceContext(mock(SCMSourceCriteria.class),
+                mock(SCMHeadObserver.class));
+        GitHubSCMSourceStatusChecksTrait trait = new GitHubSCMSourceStatusChecksTrait();
+
+        // disable notifications, the trait configuration should be ignored
+        context.withNotificationsDisabled(true);
+        trait.setSkipNotifications(false);
+        trait.decorateContext(context);
+        assertThat(context.notificationsDisabled()).isTrue();
+
+        // enable notifications, the trait configuration should be applied
+        context.withNotificationsDisabled(false);
+        trait.setSkipNotifications(true);
+        trait.decorateContext(context);
+        assertThat(context.notificationsDisabled()).isTrue();
+    }
+}


### PR DESCRIPTION
Fixes: https://github.com/jenkinsci/github-checks-plugin/pull/102#issuecomment-776099837

We apply the trait configuration for disabling branch source notification for each build, however, if the users are also using some other plugins that also disable the notifications while not checking our configuration, we may end up enabling the notifications again. Thus, for compatibility, we should check if the notifications have already been disabled before applying our configurations.