### PR TITLE
Fix suppress log property doesn't really expose to status publisher in api

### DIFF
--- a/src/main/java/io/jenkins/plugins/checks/github/status/GitHubStatusChecksConfigurations.java
+++ b/src/main/java/io/jenkins/plugins/checks/github/status/GitHubStatusChecksConfigurations.java
@@ -25,7 +25,8 @@ public interface GitHubStatusChecksConfigurations {
      */
     boolean isUnstableBuildNeutral();
 
-    /** Defines whether to suppress log output in status checks.
+    /**
+     * Defines whether to suppress log output in status checks.
      *
      * @return true to suppress logs
      */

--- a/src/main/java/io/jenkins/plugins/checks/github/status/GitHubStatusChecksProperties.java
+++ b/src/main/java/io/jenkins/plugins/checks/github/status/GitHubStatusChecksProperties.java
@@ -57,6 +57,11 @@ public class GitHubStatusChecksProperties extends AbstractStatusChecksProperties
         return getConfigurations(job).orElse(DEFAULT_CONFIGURATION).isUnstableBuildNeutral();
     }
 
+    @Override
+    public boolean isSuppressLogs(final Job<?, ?> job) {
+        return getConfigurations(job).orElse(DEFAULT_CONFIGURATION).isSuppressLogs();
+    }
+
     private Optional<GitHubStatusChecksConfigurations> getConfigurations(final Job<?, ?> job) {
         Optional<GitHubSCMSource> gitHubSCMSource = scmFacade.findGitHubSCMSource(job);
         if (gitHubSCMSource.isPresent()) {

--- a/src/test/java/io/jenkins/plugins/checks/github/status/GitHubStatusChecksPropertiesTest.java
+++ b/src/test/java/io/jenkins/plugins/checks/github/status/GitHubStatusChecksPropertiesTest.java
@@ -28,9 +28,10 @@ class GitHubStatusChecksPropertiesTest {
         trait.setName("GitHub SCM Source");
         trait.setSkip(true);
         trait.setUnstableBuildNeutral(true);
+        trait.setSuppressLogs(true);
 
         assertJobWithStatusChecksProperties(job, new GitHubStatusChecksProperties(scmFacade),
-                true, "GitHub SCM Source", true, true);
+                true, "GitHub SCM Source", true, true, true);
     }
 
     @Test
@@ -47,9 +48,10 @@ class GitHubStatusChecksPropertiesTest {
         extension.setName("Git SCM");
         extension.setSkip(true);
         extension.setUnstableBuildNeutral(true);
+        extension.setSuppressLogs(true);
 
         assertJobWithStatusChecksProperties(job, new GitHubStatusChecksProperties(scmFacade),
-                true, "Git SCM", true, true);
+                true, "Git SCM", true, true, true);
     }
 
     @Test
@@ -61,7 +63,7 @@ class GitHubStatusChecksPropertiesTest {
         when(scmFacade.findGitHubSCMSource(job)).thenReturn(Optional.of(source));
 
         assertJobWithStatusChecksProperties(job, new GitHubStatusChecksProperties(scmFacade),
-                true, "Jenkins", false, false);
+                true, "Jenkins", false, false, false);
     }
 
     @Test
@@ -75,7 +77,7 @@ class GitHubStatusChecksPropertiesTest {
         when(scm.getExtensions()).thenReturn(extensionList);
 
         assertJobWithStatusChecksProperties(job, new GitHubStatusChecksProperties(scmFacade),
-                true, "Jenkins", false, false);
+                true, "Jenkins", false, false, false);
     }
 
     @Test
@@ -86,16 +88,18 @@ class GitHubStatusChecksPropertiesTest {
         when(scmFacade.findGitSCM(job)).thenReturn(Optional.empty());
         when(scmFacade.findGitHubSCMSource(job)).thenReturn(Optional.empty());
         assertJobWithStatusChecksProperties(job, new GitHubStatusChecksProperties(scmFacade),
-                false, "Jenkins", false, false);
+                false, "Jenkins", false, false, false);
     }
 
     private void assertJobWithStatusChecksProperties(final Job job, final GitHubStatusChecksProperties properties,
                                                      final boolean isApplicable, final String name,
-                                                     final boolean isSkip, final boolean isUnstableBuildNeutral) {
+                                                     final boolean isSkip, final boolean isUnstableBuildNeutral,
+                                                     final boolean isSuppressLogs) {
         assertThat(properties.isApplicable(job)).isEqualTo(isApplicable);
         assertThat(properties.getName(job)).isEqualTo(name);
         assertThat(properties.isSkipped(job)).isEqualTo(isSkip);
         assertThat(properties.isUnstableBuildNeutral(job)).isEqualTo(isUnstableBuildNeutral);
+        assertThat(properties.isSuppressLogs(job)).isEqualTo(isSuppressLogs);
     }
 }
 


### PR DESCRIPTION
The previous implementation https://github.com/jenkinsci/github-checks-plugin/pull/138 to suppress log just add the ability to allow the user to control the configurations of different projects, but properties that the checks-api actually using are gathered from sub-classes of [AbstractStatusChecksProperties](https://github.com/jenkinsci/checks-api-plugin/blob/master/src/main/java/io/jenkins/plugins/checks/status/AbstractStatusChecksProperties.java), which is [GitHubStatusChecksProperties](https://github.com/jenkinsci/github-checks-plugin/blob/master/src/main/java/io/jenkins/plugins/checks/github/status/GitHubStatusChecksProperties.java) here.

See https://github.com/jenkinsci/checks-api-plugin/blob/86bdb307e5d25939a371eb79ae3ac7e35f65ff53/src/main/java/io/jenkins/plugins/checks/status/BuildStatusChecksPublisher.java#L64-L70

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
