### PR TITLE
Lookup previous build using build id and re-use any parameters

### DIFF
--- a/src/main/java/io/jenkins/plugins/checks/github/CheckRunGHEventSubscriber.java
+++ b/src/main/java/io/jenkins/plugins/checks/github/CheckRunGHEventSubscriber.java
@@ -85,8 +85,6 @@ public class CheckRunGHEventSubscriber extends GHEventsSubscriber {
             GHEventPayload.CheckRun checkRun = GitHub.offline().parseEventPayload(new StringReader(payload), GHEventPayload.CheckRun.class);
             JSONObject payloadJSON = new JSONObject(payload);
 
-            branchName = payloadJSON.getJSONObject("check_run").getJSONObject("check_suite").getString("head_branch");
-
             if (!RERUN_ACTION.equals(checkRun.getAction())) {
                 LOGGER.log(Level.FINE,
                         "Unsupported check run action: " + checkRun.getAction().replaceAll("[\r\n]", ""));

--- a/src/main/java/io/jenkins/plugins/checks/github/CheckRunGHEventSubscriber.java
+++ b/src/main/java/io/jenkins/plugins/checks/github/CheckRunGHEventSubscriber.java
@@ -2,6 +2,8 @@ package io.jenkins.plugins.checks.github;
 
 import java.io.IOException;
 import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Optional;
@@ -22,10 +24,13 @@ import org.kohsuke.github.GitHub;
 import org.jenkinsci.plugins.github.extension.GHEventsSubscriber;
 import org.jenkinsci.plugins.github.extension.GHSubscriberEvent;
 import hudson.Extension;
+import hudson.model.Action;
 import hudson.model.Cause;
 import hudson.model.CauseAction;
 import hudson.model.Item;
 import hudson.model.Job;
+import hudson.model.ParametersAction;
+import hudson.model.Run;
 import hudson.security.ACL;
 import hudson.security.ACLContext;
 import jenkins.model.ParameterizedJobMixIn;
@@ -80,6 +85,8 @@ public class CheckRunGHEventSubscriber extends GHEventsSubscriber {
             GHEventPayload.CheckRun checkRun = GitHub.offline().parseEventPayload(new StringReader(payload), GHEventPayload.CheckRun.class);
             JSONObject payloadJSON = new JSONObject(payload);
 
+            branchName = payloadJSON.getJSONObject("check_run").getJSONObject("check_suite").getString("head_branch");
+
             if (!RERUN_ACTION.equals(checkRun.getAction())) {
                 LOGGER.log(Level.FINE,
                         "Unsupported check run action: " + checkRun.getAction().replaceAll("[\r\n]", ""));
@@ -100,18 +107,29 @@ public class CheckRunGHEventSubscriber extends GHEventsSubscriber {
     private void scheduleRerun(final GHEventPayload.CheckRun checkRun, final String branchName) {
         final GHRepository repository = checkRun.getRepository();
 
-        Optional<Job<?, ?>> optionalJob = jenkinsFacade.getJob(checkRun.getCheckRun().getExternalId());
-        if (optionalJob.isPresent()) {
-            Job<?, ?> job = optionalJob.get();
+        Optional<Run<?, ?>> optionalRun = jenkinsFacade.getBuild(checkRun.getCheckRun().getExternalId());
+        if (optionalRun.isPresent()) {
+            Run<?, ?> run = optionalRun.get();
+            Job<?, ?> job = run.getParent();
+
             Cause cause = new GitHubChecksRerunActionCause(checkRun.getSender().getLogin(), branchName);
-            ParameterizedJobMixIn.scheduleBuild2(job, 0, new CauseAction(cause));
+
+            List<Action> actions = new ArrayList<>();
+            actions.add(new CauseAction(cause));
+
+            ParametersAction paramAction = run.getAction(ParametersAction.class);
+            if (paramAction != null) {
+                actions.add(paramAction);
+            }
+
+            ParameterizedJobMixIn.scheduleBuild2(job, 0, actions.toArray(new Action[0]));
 
             LOGGER.log(Level.INFO, String.format("Scheduled rerun (build #%d) for job %s, requested by %s",
                     job.getNextBuildNumber(), jenkinsFacade.getFullNameOf(job),
                     checkRun.getSender().getLogin()).replaceAll("[\r\n]", ""));
         }
         else {
-            LOGGER.log(Level.WARNING, String.format("No job found for rerun request from repository: %s and job: %s",
+            LOGGER.log(Level.WARNING, String.format("No build found for rerun request from repository: %s and id: %s",
                     repository.getFullName(), checkRun.getCheckRun().getExternalId()).replaceAll("[\r\n]", ""));
         }
     }

--- a/src/main/java/io/jenkins/plugins/checks/github/CheckRunGHEventSubscriber.java
+++ b/src/main/java/io/jenkins/plugins/checks/github/CheckRunGHEventSubscriber.java
@@ -3,8 +3,8 @@ package io.jenkins.plugins.checks.github;
 import java.io.IOException;
 import java.io.StringReader;
 import java.util.ArrayList;
-import java.util.List;
 import java.util.Collections;
+import java.util.List;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
@@ -83,13 +83,13 @@ public class CheckRunGHEventSubscriber extends GHEventsSubscriber {
         final String payload = event.getPayload();
         try {
             GHEventPayload.CheckRun checkRun = GitHub.offline().parseEventPayload(new StringReader(payload), GHEventPayload.CheckRun.class);
-            JSONObject payloadJSON = new JSONObject(payload);
-
             if (!RERUN_ACTION.equals(checkRun.getAction())) {
                 LOGGER.log(Level.FINE,
                         "Unsupported check run action: " + checkRun.getAction().replaceAll("[\r\n]", ""));
                 return;
             }
+
+            JSONObject payloadJSON = new JSONObject(payload);
 
             LOGGER.log(Level.INFO, "Received rerun request through GitHub checks API.");
             try (ACLContext ignored = ACL.as(ACL.SYSTEM)) {

--- a/src/main/java/io/jenkins/plugins/checks/github/GitHubChecksPublisher.java
+++ b/src/main/java/io/jenkins/plugins/checks/github/GitHubChecksPublisher.java
@@ -119,8 +119,12 @@ public class GitHubChecksPublisher extends ChecksPublisher {
     private GHCheckRunBuilder applyDetails(final GHCheckRunBuilder builder, final GitHubChecksDetails details) {
         builder
                 .withStatus(details.getStatus())
-                .withExternalID(context.getRun().get().getExternalizableId())
                 .withDetailsURL(details.getDetailsURL().orElse(context.getURL()));
+
+        if (context.getRun().isPresent()) {
+            final String externalId = context.getRun().get().getExternalizableId();
+            builder.withExternalID(externalId);
+        }
 
         if (details.getConclusion().isPresent()) {
             builder.withConclusion(details.getConclusion().get())

--- a/src/main/java/io/jenkins/plugins/checks/github/GitHubChecksPublisher.java
+++ b/src/main/java/io/jenkins/plugins/checks/github/GitHubChecksPublisher.java
@@ -119,7 +119,7 @@ public class GitHubChecksPublisher extends ChecksPublisher {
     private GHCheckRunBuilder applyDetails(final GHCheckRunBuilder builder, final GitHubChecksDetails details) {
         builder
                 .withStatus(details.getStatus())
-                .withExternalID(context.getJob().getFullName())
+                .withExternalID(context.getRun().get().getExternalizableId())
                 .withDetailsURL(details.getDetailsURL().orElse(context.getURL()));
 
         if (details.getConclusion().isPresent()) {

--- a/src/test/java/io/jenkins/plugins/checks/github/CheckRunGHEventSubscriberTest.java
+++ b/src/test/java/io/jenkins/plugins/checks/github/CheckRunGHEventSubscriberTest.java
@@ -13,7 +13,6 @@ import org.kohsuke.github.GHEvent;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.Collections;
 import java.util.Optional;
 import java.util.logging.Level;
 
@@ -109,7 +108,9 @@ class CheckRunGHEventSubscriberTest {
         when(jenkinsFacade.getBuild("codingstyle/PR-1#2")).thenReturn(Optional.of(run));
         when(jenkinsFacade.getFullNameOf(job)).thenReturn("codingstyle/PR-1");
         when(run.getParent()).thenReturn(job);
-        when(run.getAction(ParametersAction.class)).thenReturn(null);
+        when(run.getAction(ParametersAction.class)).thenReturn(
+            new ParametersAction(new StringParameterValue("test_key", "test_value"))
+        );
         when(job.getNextBuildNumber()).thenReturn(1);
         when(job.getName()).thenReturn("PR-1");
 

--- a/src/test/java/io/jenkins/plugins/checks/github/CheckRunGHEventSubscriberTest.java
+++ b/src/test/java/io/jenkins/plugins/checks/github/CheckRunGHEventSubscriberTest.java
@@ -92,17 +92,6 @@ class CheckRunGHEventSubscriberTest {
     }
 
     @Test
-    void shouldThrowExceptionWhenHeadBranchMissingFromPayload() throws IOException {
-        assertThatThrownBy(
-            () -> {
-                new CheckRunGHEventSubscriber(mock(JenkinsFacade.class), mock(SCMFacade.class))
-                  .onEvent(createEventWithRerunRequest(RERUN_REQUEST_JSON_FOR_PR_MISSING_CHECKSUITE_HEAD_BRANCH));
-            })
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessageContaining("Could not parse check run event:");
-    }
-
-    @Test
     void shouldIgnoreCheckRunEventWithoutRerequestedAction() throws IOException {
         loggerRule.record(CheckRunGHEventSubscriber.class.getName(), Level.FINE).capture(1);
         new CheckRunGHEventSubscriber(mock(JenkinsFacade.class), mock(SCMFacade.class))

--- a/src/test/resources/io/jenkins/plugins/checks/github/CheckRunGHEventSubscriberTest/check-run-event-with-rerun-action-for-master.json
+++ b/src/test/resources/io/jenkins/plugins/checks/github/CheckRunGHEventSubscriberTest/check-run-event-with-rerun-action-for-master.json
@@ -4,7 +4,7 @@
     "id": 993663296,
     "node_id": "MDg6Q2hlY2tSdW45OTM2NjMyOTY=",
     "head_sha": "b22fdfec1127073e509224a99a7704eeebdebe11",
-    "external_id": "XiongKezhi/codingstyle/master",
+    "external_id": "codingstyle/master#8",
     "url": "https://api.github.com/repos/XiongKezhi/codingstyle/check-runs/993663296",
     "html_url": "https://github.com/XiongKezhi/codingstyle/runs/993663296",
     "details_url": "http://127.0.0.1:8080/job/free-coding-style/8/display/redirect",

--- a/src/test/resources/io/jenkins/plugins/checks/github/CheckRunGHEventSubscriberTest/check-run-event-with-rerun-action-for-pr-missing-check-suite-head-branch.json
+++ b/src/test/resources/io/jenkins/plugins/checks/github/CheckRunGHEventSubscriberTest/check-run-event-with-rerun-action-for-pr-missing-check-suite-head-branch.json
@@ -4,7 +4,7 @@
     "id": 993923912,
     "node_id": "MDg6Q2hlY2tSdW45OTM5MjM5MTI=",
     "head_sha": "3c0ea12c02129ff4919afe087616d84547d93539",
-    "external_id": "XiongKezhi/codingstyle/PR-1",
+    "external_id": "codingstyle/PR-1#2",
     "url": "https://api.github.com/repos/XiongKezhi/codingstyle/check-runs/993923912",
     "html_url": "https://github.com/XiongKezhi/codingstyle/runs/993923912",
     "details_url": "http://127.0.0.1:8080/job/pipeline-coding-style/job/PR-1/2/display/redirect",

--- a/src/test/resources/io/jenkins/plugins/checks/github/CheckRunGHEventSubscriberTest/check-run-event-with-rerun-action-for-pr-missing-check-suite.json
+++ b/src/test/resources/io/jenkins/plugins/checks/github/CheckRunGHEventSubscriberTest/check-run-event-with-rerun-action-for-pr-missing-check-suite.json
@@ -4,7 +4,7 @@
     "id": 993923912,
     "node_id": "MDg6Q2hlY2tSdW45OTM5MjM5MTI=",
     "head_sha": "3c0ea12c02129ff4919afe087616d84547d93539",
-    "external_id": "XiongKezhi/codingstyle/PR-1",
+    "external_id": "codingstyle/PR-1#2",
     "url": "https://api.github.com/repos/XiongKezhi/codingstyle/check-runs/993923912",
     "html_url": "https://github.com/XiongKezhi/codingstyle/runs/993923912",
     "details_url": "http://127.0.0.1:8080/job/pipeline-coding-style/job/PR-1/2/display/redirect",

--- a/src/test/resources/io/jenkins/plugins/checks/github/CheckRunGHEventSubscriberTest/check-run-event-with-rerun-action-for-pr.json
+++ b/src/test/resources/io/jenkins/plugins/checks/github/CheckRunGHEventSubscriberTest/check-run-event-with-rerun-action-for-pr.json
@@ -4,7 +4,7 @@
     "id": 993923912,
     "node_id": "MDg6Q2hlY2tSdW45OTM5MjM5MTI=",
     "head_sha": "3c0ea12c02129ff4919afe087616d84547d93539",
-    "external_id": "XiongKezhi/codingstyle/PR-1",
+    "external_id": "codingstyle/PR-1#2",
     "url": "https://api.github.com/repos/XiongKezhi/codingstyle/check-runs/993923912",
     "html_url": "https://github.com/XiongKezhi/codingstyle/runs/993923912",
     "details_url": "http://127.0.0.1:8080/job/pipeline-coding-style/job/PR-1/2/display/redirect",


### PR DESCRIPTION
When using the generic-webhook-plugin, webhook payloads are parsed (via jsonpath) and injected into the original build as parameters.  When re-requesting a check from github, we need the ability to look up the parameters of the original build so that the build has the parameters from the original build.  Otherwise empty/default parameters would cause the build to fail (even which git hash we check out is driven by a parameter).

In order to accomplish this, we use the jenkins externalized build id as the external_id when publishing the check.  When the check is re-triggered, we are able to look up the original build and re-inject the parameters.

I believe this may be a generic solution to https://github.com/jenkinsci/github-checks-plugin/issues/223.  Our issue is that instead of a single parameter, we have 10-20 parameters so we needed a solution which is able to re-populate those parameters.

I realize there are risks with changing the mechanism by which we look up the job.  What I would like some feedback on is whether this change should be compatible with the original intent of the plugin (via a multibranch pipeline).  There is also a risk that the original build has fallen off the history and can no longer be looked up, but it's unclear to me how big of an issue that would be in practice.
