### PR TITLE
Handle null field in re-run request for head_branch

### DIFF
--- a/src/main/java/io/jenkins/plugins/checks/github/CheckRunGHEventSubscriber.java
+++ b/src/main/java/io/jenkins/plugins/checks/github/CheckRunGHEventSubscriber.java
@@ -79,11 +79,7 @@ public class CheckRunGHEventSubscriber extends GHEventsSubscriber {
         try {
             GHEventPayload.CheckRun checkRun = GitHub.offline().parseEventPayload(new StringReader(payload), GHEventPayload.CheckRun.class);
             JSONObject payloadJSON = new JSONObject(payload);
-            JSONObject checkSuite = payloadJSON.getJSONObject("check_run").getJSONObject("check_suite");
-            String branchName = null;
-            if (checkSuite.has("head_branch")) {
-                branchName = checkSuite.getString("head_branch");
-            }
+            String branchName = payloadJSON.getJSONObject("check_run").getJSONObject("check_suite").optString("head_branch");
             
             if (!RERUN_ACTION.equals(checkRun.getAction())) {
                 LOGGER.log(Level.FINE,

--- a/src/main/java/io/jenkins/plugins/checks/github/CheckRunGHEventSubscriber.java
+++ b/src/main/java/io/jenkins/plugins/checks/github/CheckRunGHEventSubscriber.java
@@ -79,8 +79,7 @@ public class CheckRunGHEventSubscriber extends GHEventsSubscriber {
         try {
             GHEventPayload.CheckRun checkRun = GitHub.offline().parseEventPayload(new StringReader(payload), GHEventPayload.CheckRun.class);
             JSONObject payloadJSON = new JSONObject(payload);
-            String branchName = payloadJSON.getJSONObject("check_run").getJSONObject("check_suite").optString("head_branch");
-            
+
             if (!RERUN_ACTION.equals(checkRun.getAction())) {
                 LOGGER.log(Level.FINE,
                         "Unsupported check run action: " + checkRun.getAction().replaceAll("[\r\n]", ""));
@@ -89,6 +88,7 @@ public class CheckRunGHEventSubscriber extends GHEventsSubscriber {
 
             LOGGER.log(Level.INFO, "Received rerun request through GitHub checks API.");
             try (ACLContext ignored = ACL.as(ACL.SYSTEM)) {
+                String branchName = payloadJSON.getJSONObject("check_run").getJSONObject("check_suite").optString("head_branch");
                 scheduleRerun(checkRun, branchName);
             }
         }

--- a/src/test/resources/io/jenkins/plugins/checks/github/CheckRunGHEventSubscriberTest/check-run-event-with-rerun-action-for-pr-missing-check-suite-head-branch.json
+++ b/src/test/resources/io/jenkins/plugins/checks/github/CheckRunGHEventSubscriberTest/check-run-event-with-rerun-action-for-pr-missing-check-suite-head-branch.json
@@ -25,6 +25,7 @@
       "node_id": "MDEwOkNoZWNrU3VpdGUxMDYwNDA3Nzg0",
       "head_sha": "3c0ea12c02129ff4919afe087616d84547d93539",
       "status": "queued",
+      "head_branch": null,
       "conclusion": null,
       "url": "https://api.github.com/repos/XiongKezhi/codingstyle/check-suites/1060407784",
       "before": "2a5453f64dc2dc2433411afbbbfaf757e8ff1793",


### PR DESCRIPTION
The library we use for json is rubbish, a `has` check from https://github.com/jenkinsci/github-checks-plugin/pull/237 returns true for null so we hit the same issue.

The tests were omitting the field but GitHub sends the field with `null` as the value

Few solutions in https://stackoverflow.com/questions/12585492/how-to-test-if-a-jsonobject-is-null-or-doesnt-exist

I went with `optString` which seems to work fine

relates to https://github.com/jenkins-infra/helpdesk/issues/2738