### PR TITLE
Use `failure` rather than `cancelled` or `timed_out` `conclusion`s

### DIFF
--- a/src/main/java/io/jenkins/plugins/checks/github/GitHubChecksDetails.java
+++ b/src/main/java/io/jenkins/plugins/checks/github/GitHubChecksDetails.java
@@ -130,11 +130,9 @@ class GitHubChecksDetails {
     public Optional<Conclusion> getConclusion() {
         switch (details.getConclusion()) {
             case SKIPPED: // SKIPPED doesn't work for GitHub, though documented
-            case CANCELED:
-                return Optional.of(Conclusion.CANCELLED);
-            case TIME_OUT:
-                return Optional.of(Conclusion.TIMED_OUT);
             case FAILURE:
+            case CANCELED: // TODO use CANCELLED if https://github.com/github/feedback/discussions/10255 is fixed
+            case TIME_OUT: // TODO TIMED_OUT as above
                 return Optional.of(Conclusion.FAILURE);
             case NEUTRAL:
                 return Optional.of(Conclusion.NEUTRAL);


### PR DESCRIPTION
Working around https://github.com/github/feedback/discussions/10255 as suggested in https://github.com/jenkins-infra/helpdesk/issues/2741#issuecomment-1036624213. **Untested**. CC @timja @basil @dduportal @lemeurherve @MarkEWaite