### PR TITLE
Switch caching to setup-java

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -21,18 +21,11 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: ${{ matrix.java }}
-
-      - name: Cache dependencies
-        uses: actions/cache@v2.1.7
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven
+          cache: 'maven'
 
       - name: Build with Maven
         run: mvn -Penable-jacoco clean verify -B -V -ntp


### PR DESCRIPTION
Noticed because of https://github.com/jenkinsci/checks-api-plugin/pull/151 which is unnecessary 