### PR TITLE
Add symbols for SCM traits

### DIFF
--- a/src/main/java/io/jenkins/plugins/checks/github/config/GitHubSCMSourceChecksTrait.java
+++ b/src/main/java/io/jenkins/plugins/checks/github/config/GitHubSCMSourceChecksTrait.java
@@ -5,10 +5,12 @@ import jenkins.scm.api.SCMSource;
 import jenkins.scm.api.trait.SCMSourceContext;
 import jenkins.scm.api.trait.SCMSourceTrait;
 import jenkins.scm.api.trait.SCMSourceTraitDescriptor;
+import jenkins.scm.impl.trait.Discovery;
 import org.jenkinsci.plugins.github_branch_source.GitHubSCMSource;
 import org.jenkinsci.plugins.github_branch_source.GitHubSCMSourceContext;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
+import org.jenkinsci.Symbol;
 
 /**
  * GitHub checks configurations for jobs with {@link GitHubSCMSource}.
@@ -38,7 +40,9 @@ public class GitHubSCMSourceChecksTrait extends SCMSourceTrait implements GitHub
     /**
      * Descriptor implementation for {@link GitHubSCMSourceChecksTrait}.
      */
+    @Symbol("gitHubSourceChecks")
     @Extension
+    @Discovery
     public static class DescriptorImpl extends SCMSourceTraitDescriptor {
         /**
          * Returns the display name.

--- a/src/main/java/io/jenkins/plugins/checks/github/status/GitHubSCMSourceStatusChecksTrait.java
+++ b/src/main/java/io/jenkins/plugins/checks/github/status/GitHubSCMSourceStatusChecksTrait.java
@@ -7,12 +7,14 @@ import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
 import org.jenkinsci.plugins.github_branch_source.GitHubSCMSource;
 import org.jenkinsci.plugins.github_branch_source.GitHubSCMSourceContext;
+import org.jenkinsci.Symbol;
 import hudson.Extension;
 import hudson.util.FormValidation;
 import jenkins.scm.api.SCMSource;
 import jenkins.scm.api.trait.SCMSourceContext;
 import jenkins.scm.api.trait.SCMSourceTrait;
 import jenkins.scm.api.trait.SCMSourceTraitDescriptor;
+import jenkins.scm.impl.trait.Discovery;
 
 import io.jenkins.plugins.checks.status.AbstractStatusChecksProperties;
 
@@ -134,7 +136,9 @@ public class GitHubSCMSourceStatusChecksTrait extends SCMSourceTrait implements 
     /**
      * Descriptor implementation for {@link GitHubSCMSourceStatusChecksTrait}.
      */
+    @Symbol("gitHubStatusChecks")
     @Extension
+    @Discovery
     public static class DescriptorImpl extends SCMSourceTraitDescriptor {
         /**
          * Returns the display name.


### PR DESCRIPTION
Hi,

Add symbols to avoid using configure block when configuring those traits via JobDSL

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did

![github_check_status](https://user-images.githubusercontent.com/825750/187599980-363e2b15-4fcf-407e-90e9-426f69cfb817.PNG)

![github_check_source](https://user-images.githubusercontent.com/825750/187599983-7940ef44-a805-46f8-a5bb-426ddf975d7f.PNG)


Regards,
