### PR TITLE
Change default behaviour of "Suppress progress updates in job check"

### DIFF
--- a/src/main/java/io/jenkins/plugins/checks/github/GitHubChecksGlobalConfig.java
+++ b/src/main/java/io/jenkins/plugins/checks/github/GitHubChecksGlobalConfig.java
@@ -1,0 +1,46 @@
+package io.jenkins.plugins.checks.github;
+
+import hudson.Extension;
+import jenkins.model.GlobalConfiguration;
+import net.sf.json.JSONObject;
+import org.kohsuke.stapler.StaplerRequest;
+
+@Extension
+public class GitHubChecksGlobalConfig extends GlobalConfiguration {
+
+
+    private boolean skipProgressUpdates = false;
+    private boolean enforceSkipProgressUpdates = false;
+
+    public static GitHubChecksGlobalConfig get() {
+        return GlobalConfiguration.all().get(GitHubChecksGlobalConfig.class);
+    }
+
+    public GitHubChecksGlobalConfig() {
+        load();
+    }
+
+    public synchronized boolean isSkipProgressUpdates() {
+        return skipProgressUpdates;
+    }
+
+    public synchronized void setSkipProgressUpdates(boolean skipProgressUpdates) {
+        this.skipProgressUpdates = skipProgressUpdates;
+        save();
+    }
+
+    public synchronized boolean isEnforceSkipProgressUpdates() {
+        return enforceSkipProgressUpdates;
+    }
+
+    public synchronized void setEnforceSkipProgressUpdates(boolean enforceSkipProgressUpdates) {
+        this.enforceSkipProgressUpdates = enforceSkipProgressUpdates;
+        save();
+    }
+
+    @Override
+    public boolean configure(StaplerRequest req, JSONObject json) throws FormException {
+        req.bindJSON(this, json);
+        return true;
+    }
+}

--- a/src/main/java/io/jenkins/plugins/checks/github/status/GitHubSCMSourceStatusChecksTrait.java
+++ b/src/main/java/io/jenkins/plugins/checks/github/status/GitHubSCMSourceStatusChecksTrait.java
@@ -27,13 +27,14 @@ public class GitHubSCMSourceStatusChecksTrait extends SCMSourceTrait implements 
     private boolean unstableBuildNeutral = false;
     private String name = "Jenkins";
     private boolean suppressLogs = false;
-    private boolean skipProgressUpdates = false;
+    private boolean skipProgressUpdates = DescriptorImpl.defaultSkipProgressUpdates;
 
     /**
      * Constructor for stapler.
      */
     @DataBoundConstructor
     public GitHubSCMSourceStatusChecksTrait() {
+
         super();
     }
 
@@ -136,6 +137,11 @@ public class GitHubSCMSourceStatusChecksTrait extends SCMSourceTrait implements 
      */
     @Extension
     public static class DescriptorImpl extends SCMSourceTraitDescriptor {
+        public static final boolean defaultSkipProgressUpdates;
+
+        static {
+            defaultSkipProgressUpdates = true;
+        }
         /**
          * Returns the display name.
          *

--- a/src/main/java/io/jenkins/plugins/checks/github/status/GitHubSCMSourceStatusChecksTrait.java
+++ b/src/main/java/io/jenkins/plugins/checks/github/status/GitHubSCMSourceStatusChecksTrait.java
@@ -1,5 +1,6 @@
 package io.jenkins.plugins.checks.github.status;
 
+import io.jenkins.plugins.checks.github.GitHubChecksGlobalConfig;
 import org.apache.commons.lang3.StringUtils;
 
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -28,6 +29,9 @@ public class GitHubSCMSourceStatusChecksTrait extends SCMSourceTrait implements 
     private String name = "Jenkins";
     private boolean suppressLogs = false;
     private boolean skipProgressUpdates = DescriptorImpl.defaultSkipProgressUpdates;
+
+    public GitHubChecksGlobalConfig globalConfig = GitHubChecksGlobalConfig.get();
+    public boolean enforceSkipProgressUpdates = GitHubChecksGlobalConfig.get().isEnforceSkipProgressUpdates();
 
     /**
      * Constructor for stapler.
@@ -72,6 +76,9 @@ public class GitHubSCMSourceStatusChecksTrait extends SCMSourceTrait implements 
     public boolean isSkipNotifications() {
         return skipNotifications;
     }
+
+    @Override
+    public boolean isEnforceSkipProgressUpdates() { return enforceSkipProgressUpdates; }
 
     @Override
     public boolean isSuppressLogs() {
@@ -138,8 +145,10 @@ public class GitHubSCMSourceStatusChecksTrait extends SCMSourceTrait implements 
     @Extension
     public static class DescriptorImpl extends SCMSourceTraitDescriptor {
         public static final boolean defaultSkipProgressUpdates;
+        public static final boolean enforceSkipProgressUpdates;
 
         static {
+            enforceSkipProgressUpdates = GitHubChecksGlobalConfig.get().isEnforceSkipProgressUpdates();
             defaultSkipProgressUpdates = true;
         }
         /**

--- a/src/main/java/io/jenkins/plugins/checks/github/status/GitHubStatusChecksConfigurations.java
+++ b/src/main/java/io/jenkins/plugins/checks/github/status/GitHubStatusChecksConfigurations.java
@@ -1,5 +1,7 @@
 package io.jenkins.plugins.checks.github.status;
 
+import hudson.model.Job;
+
 /**
  * Configurations for users to customize status checks.
  */
@@ -39,6 +41,8 @@ public interface GitHubStatusChecksConfigurations {
      * @return true if progress updates should be skipped.
      */
     boolean isSkipProgressUpdates();
+
+    boolean isEnforceSkipProgressUpdates();
 }
 
 class DefaultGitHubStatusChecksConfigurations implements GitHubStatusChecksConfigurations {
@@ -64,6 +68,11 @@ class DefaultGitHubStatusChecksConfigurations implements GitHubStatusChecksConfi
 
     @Override
     public boolean isSkipProgressUpdates() {
+        return false;
+    }
+
+    @Override
+    public boolean isEnforceSkipProgressUpdates() {
         return false;
     }
 }

--- a/src/main/java/io/jenkins/plugins/checks/github/status/GitHubStatusChecksProperties.java
+++ b/src/main/java/io/jenkins/plugins/checks/github/status/GitHubStatusChecksProperties.java
@@ -5,6 +5,7 @@ import java.util.stream.Stream;
 
 import edu.hm.hafner.util.VisibleForTesting;
 
+import io.jenkins.plugins.checks.github.GitHubChecksGlobalConfig;
 import org.jenkinsci.plugins.github_branch_source.GitHubSCMSource;
 import hudson.Extension;
 import hudson.model.Job;
@@ -66,7 +67,10 @@ public class GitHubStatusChecksProperties extends AbstractStatusChecksProperties
 
     @Override
     public boolean isSkipProgressUpdates(final Job<?, ?> job) {
-        return getConfigurations(job).orElse(DEFAULT_CONFIGURATION).isSkipProgressUpdates();
+        if (GitHubChecksGlobalConfig.get().isEnforceSkipProgressUpdates())
+            return GitHubChecksGlobalConfig.get().isSkipProgressUpdates();
+        else
+            return getConfigurations(job).orElse(DEFAULT_CONFIGURATION).isSkipProgressUpdates();
     }
 
     private Optional<GitHubStatusChecksConfigurations> getConfigurations(final Job<?, ?> job) {

--- a/src/main/java/io/jenkins/plugins/checks/github/status/GitSCMStatusChecksExtension.java
+++ b/src/main/java/io/jenkins/plugins/checks/github/status/GitSCMStatusChecksExtension.java
@@ -1,5 +1,6 @@
 package io.jenkins.plugins.checks.github.status;
 
+import io.jenkins.plugins.checks.github.GitHubChecksGlobalConfig;
 import org.apache.commons.lang3.StringUtils;
 
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -22,6 +23,7 @@ public class GitSCMStatusChecksExtension extends GitSCMExtension implements GitH
     private String name = "Jenkins";
     private boolean suppressLogs;
     private boolean skipProgressUpdates = false;
+    public boolean enforceSkipProgressUpdates = GitHubChecksGlobalConfig.get().isEnforceSkipProgressUpdates();
 
     /**
      * Constructor for stapler.
@@ -55,6 +57,9 @@ public class GitSCMStatusChecksExtension extends GitSCMExtension implements GitH
     public boolean isSkipProgressUpdates() {
         return skipProgressUpdates;
     }
+
+    @Override
+    public boolean isEnforceSkipProgressUpdates() { return enforceSkipProgressUpdates; }
 
     @DataBoundSetter
     public void setSkipProgressUpdates(final boolean skipProgressUpdates) {

--- a/src/main/resources/io/jenkins/plugins/checks/github/GitHubChecksGlobalConfig/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/checks/github/GitHubChecksGlobalConfig/config.jelly
@@ -1,0 +1,13 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <f:section title="GitHub Checks Global Configuration">
+        <f:entry title="${%Suppress progress updates in job check}" field="skipProgressUpdates"
+                 description="${%Queued, checkout and completed will still be sent}">
+            <f:checkbox default="${descriptor.defaultSkipProgressUpdates}"/>
+        </f:entry>
+        <f:entry title="${%Enforce global setting suppress progress updates in job check}" field="enforceSkipProgressUpdates"
+                 description="${%Enforce this setting.}">
+            <f:checkbox/>
+        </f:entry>
+    </f:section>
+</j:jelly>

--- a/src/main/resources/lib/github-checks/status/properties.jelly
+++ b/src/main/resources/lib/github-checks/status/properties.jelly
@@ -17,9 +17,8 @@
   <f:entry title="${%Suppress log output in checks}" field="suppressLogs">
     <f:checkbox/>
   </f:entry>
-  //Was klappt: die Zeile unten innerhalb von Entry. Aber das wollen wir nicht, weil wir es überhaupt nicht anzeigen wollen, wenn es readOnly ist.
   <j:var set="readOnlyMode" value="${descriptor.enforceSkipProgressUpdates}" />
-  <j:if test="${!readOnlyMode}">
+  <j:if test="${!readP}">
     <f:entry title="${%Suppress progress updates in job check}" field="skipProgressUpdates"
              description="${%Queued, checkout and completed will still be sent}">
       <f:checkbox default="${descriptor.defaultSkipProgressUpdates}"/>

--- a/src/main/resources/lib/github-checks/status/properties.jelly
+++ b/src/main/resources/lib/github-checks/status/properties.jelly
@@ -17,10 +17,12 @@
   <f:entry title="${%Suppress log output in checks}" field="suppressLogs">
     <f:checkbox/>
   </f:entry>
-
-  <f:entry title="${%Suppress progress updates in job check}" field="skipProgressUpdates"
-           description="${%Queued, checkout and completed will still be sent}">
-    <f:checkbox default="${descriptor.defaultSkipProgressUpdates}"/>
-  </f:entry>
-
+  //Was klappt: die Zeile unten innerhalb von Entry. Aber das wollen wir nicht, weil wir es überhaupt nicht anzeigen wollen, wenn es readOnly ist.
+  <j:var set="readOnlyMode" value="${descriptor.enforceSkipProgressUpdates}" />
+  <j:if test="${!readOnlyMode}">
+    <f:entry title="${%Suppress progress updates in job check}" field="skipProgressUpdates"
+             description="${%Queued, checkout and completed will still be sent}">
+      <f:checkbox default="${descriptor.defaultSkipProgressUpdates}"/>
+    </f:entry>
+  </j:if>
 </j:jelly>

--- a/src/main/resources/lib/github-checks/status/properties.jelly
+++ b/src/main/resources/lib/github-checks/status/properties.jelly
@@ -9,6 +9,7 @@
     <f:textbox default="Jenkins"/>
   </f:entry>
 
+
   <f:entry title="${%Publish unstable builds as neutral status checks}" field="unstableBuildNeutral">
     <f:checkbox/>
   </f:entry>
@@ -19,7 +20,7 @@
 
   <f:entry title="${%Suppress progress updates in job check}" field="skipProgressUpdates"
            description="${%Queued, checkout and completed will still be sent}">
-    <f:checkbox/>
+    <f:checkbox default="${descriptor.defaultSkipProgressUpdates}"/>
   </f:entry>
 
 </j:jelly>


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Change default behaviour of "Suppress progress updates in job check" to reduce GitHub API call because of the rate limit and add a global config for this setting. 
We tried to enforce the the global setting but we need some advice about Jelly on this 

thx to @meiswjn

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
