### PR TITLE
docs: correct required app permissions in setup description

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This plugin has been installed, along with the [General API Plugin](https://gith
  
 ## Features
 
-*Prerequsite: only GitHub App with proper permissions can publish checks, this [guide](https://github.com/jenkinsci/github-branch-source-plugin/blob/master/docs/github-app.adoc) helps you authenticate your Jenkins as a GitHub App.*
+*Prerequsite: only GitHub App with proper permissions can publish checks, this [guide](https://github.com/jenkinsci/github-branch-source-plugin/blob/master/docs/github-app.adoc) helps you authenticate your Jenkins as a GitHub App.* The permission *read/write* on *Checks* needs to be granted beside the ones already mentioned in the guide.
 
 ### Build Status Check
 


### PR DESCRIPTION
The linked [guide](https://github.com/jenkinsci/github-branch-source-plugin/blob/master/docs/github-app.adoc) to setup GH apps for authentication is missing the *checks* permission. Without that the plugin is not able to report back to GH. This changes explicitly states this in the setup description.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
