### PR TITLE
Remove Java 8 CI

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -11,8 +11,8 @@ jobs:
 
     strategy:
       matrix:
-        java: [8, 11]
-        os: [ubuntu-latest, windows-latest]
+        java: [11]
+        os: [ubuntu-latest]
 
     runs-on: ${{ matrix.os }}
     name: on ${{ matrix.os }}


### PR DESCRIPTION
I can't see any reason for Windows there either as it's tested on ci.jenkins.io
It's questionable whether we even need codecov there as it's supported in the pipeline library now