### PR TITLE
feat: adapted the [GitHubChecksPublisher] to be compatible with [Stan…

### DIFF
--- a/src/main/java/io/jenkins/plugins/checks/github/GitHubChecksContext.java
+++ b/src/main/java/io/jenkins/plugins/checks/github/GitHubChecksContext.java
@@ -2,6 +2,7 @@ package io.jenkins.plugins.checks.github;
 
 import java.util.Optional;
 
+import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
 import org.apache.commons.lang3.StringUtils;
 
 import edu.hm.hafner.util.FilteredLog;
@@ -57,7 +58,7 @@ public abstract class GitHubChecksContext {
      *
      * @return the credentials
      */
-    public GitHubAppCredentials getCredentials() {
+    public StandardUsernameCredentials getCredentials() {
         return getGitHubAppCredentials(StringUtils.defaultIfEmpty(getCredentialsId(), ""));
     }
 
@@ -78,7 +79,7 @@ public abstract class GitHubChecksContext {
         return scmFacade;
     }
 
-    protected GitHubAppCredentials getGitHubAppCredentials(final String credentialsId) {
+    protected StandardUsernameCredentials getGitHubAppCredentials(final String credentialsId) {
         return findGitHubAppCredentials(credentialsId).orElseThrow(() ->
                 new IllegalStateException("No GitHub APP credentials available for job: " + getJob().getName()));
     }
@@ -108,7 +109,7 @@ public abstract class GitHubChecksContext {
         return true;
     }
 
-    private Optional<GitHubAppCredentials> findGitHubAppCredentials(final String credentialsId) {
+    private Optional<StandardUsernameCredentials> findGitHubAppCredentials(final String credentialsId) {
         return getScmFacade().findGitHubAppCredentials(getJob(), credentialsId);
     }
 

--- a/src/main/java/io/jenkins/plugins/checks/github/GitHubChecksPublisher.java
+++ b/src/main/java/io/jenkins/plugins/checks/github/GitHubChecksPublisher.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
 import org.apache.commons.lang3.StringUtils;
 
 import edu.hm.hafner.util.VisibleForTesting;
@@ -57,14 +58,18 @@ public class GitHubChecksPublisher extends ChecksPublisher {
     /**
      * Publishes a GitHub check run.
      *
-     * @param details
-     *         the details of a check run
+     * @param details the details of a check run
      */
     @Override
     public void publish(final ChecksDetails details) {
         try {
-            GitHubAppCredentials credentials = context.getCredentials();
-            GitHub gitHub = Connector.connect(StringUtils.defaultIfBlank(credentials.getApiUri(), gitHubUrl),
+            StandardUsernameCredentials credentials = context.getCredentials();
+            String apiUri = null;
+            if (credentials instanceof GitHubAppCredentials) {
+                apiUri = ((GitHubAppCredentials) credentials).getApiUri();
+            }
+
+            GitHub gitHub = Connector.connect(StringUtils.defaultIfBlank(apiUri, gitHubUrl),
                     credentials);
 
             GitHubChecksDetails gitHubDetails = new GitHubChecksDetails(details);

--- a/src/main/java/io/jenkins/plugins/checks/github/SCMFacade.java
+++ b/src/main/java/io/jenkins/plugins/checks/github/SCMFacade.java
@@ -2,6 +2,7 @@ package io.jenkins.plugins.checks.github;
 
 import com.cloudbees.plugins.credentials.CredentialsMatchers;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import hudson.model.AbstractProject;
 import hudson.model.Job;
@@ -122,11 +123,13 @@ public class SCMFacade {
      *         the id of the target credentials
      * @return the found GitHub App credentials or empty
      */
-    public Optional<GitHubAppCredentials> findGitHubAppCredentials(final Job<?, ?> job, final String credentialsId) {
-        List<GitHubAppCredentials> credentials = CredentialsProvider.lookupCredentials(
-                GitHubAppCredentials.class, job, ACL.SYSTEM, Collections.emptyList());
-        GitHubAppCredentials appCredentials =
-                CredentialsMatchers.firstOrNull(credentials, CredentialsMatchers.withId(credentialsId));
+    public Optional<StandardUsernameCredentials> findGitHubAppCredentials(final Job<?, ?> job, final String credentialsId) {
+        List<StandardUsernameCredentials> standardUsernameCredentials = CredentialsProvider.lookupCredentials(
+                StandardUsernameCredentials.class, job, ACL.SYSTEM, Collections.emptyList());
+
+        StandardUsernameCredentials appCredentials =
+                CredentialsMatchers.firstOrNull(standardUsernameCredentials, CredentialsMatchers.withId(credentialsId));
+
         return Optional.ofNullable(appCredentials);
     }
 


### PR DESCRIPTION
### Added support for `StandardUsernameCredentials` for `github-branch-source-plugin` SCM credentials compatibility 
Adapted the `GitHubChecksPublisher` `publish` function to support `StandardUsernameCredentials` instead of always enforcing credentials of the `GitHubAppCredentials` type.

Whenever the selected credentials type is of the `GitHubAppCredentials` type, the `ApiUri` is still fetched to guarantee backwards compatibility:
```java
StandardUsernameCredentials credentials = context.getCredentials();
String apiUri = null;
if (credentials instanceof GitHubAppCredentials) {
    apiUri = ((GitHubAppCredentials) credentials).getApiUri();
}
```

**Note**: 
It is worth raising attention that all `StandardUsernameCredentials` used with this plugin should be GHA-derived tokens and should also be compatible with `github-branch-source-plugin`. 
In my use-case, the [vault-plugin-secrets-github](https://github.com/martinbaillie/vault-plugin-secrets-github) is used to generate such tokens which are then consumed by the Jenkins pipelines.

### Testing done

#### Procedure
As extracted from [here](https://github.com/jenkinsci/github-checks-plugin/blob/master/.github/workflows/maven.yml#L31), I have ran the following command to both build & run the test suite:
```sh
$ mvn -Penable-jacoco clean verify -B -V -ntp
```

I have then installed the plugin (generated **.hpi**) via the _<jenkins-server>/manage/pluginManager/advanced_ URL and restarted the Jenkins service to assert that the plugin was successfully installed.

<img width="1468" alt="image" src="https://github.com/jenkinsci/github-checks-plugin/assets/16003878/aabce09e-cc96-459e-95f5-285ad5e47481">
 
#### Tests
SCM used:
<img width="1242" alt="image" src="https://github.com/jenkinsci/github-checks-plugin/assets/16003878/5432056e-ebcb-4dc0-811b-b651b8d5afaf">


Before change using `VaultUsernamePasswordCredentialImpl`:
<img width="1010" alt="image" src="https://github.com/jenkinsci/github-checks-plugin/assets/16003878/434edef8-a9b6-46b3-8f7f-0c8b690ea1bf">

After change using `VaultUsernamePasswordCredentialImpl`:
<img width="881" alt="image" src="https://github.com/jenkinsci/github-checks-plugin/assets/16003878/f1a1632d-8a19-4c54-80c6-9cc7ef6e86ea">

GitHub:
<img width="644" alt="image" src="https://github.com/jenkinsci/github-checks-plugin/assets/16003878/1cb319dc-7b8e-496b-b56f-0829abfc6a77">

### Submitter checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue