### PR TITLE
fix: prevent publication with unsupported credential types

### DIFF
--- a/src/main/java/io/jenkins/plugins/checks/github/GitHubChecksPublisher.java
+++ b/src/main/java/io/jenkins/plugins/checks/github/GitHubChecksPublisher.java
@@ -64,6 +64,15 @@ public class GitHubChecksPublisher extends ChecksPublisher {
     public void publish(final ChecksDetails details) {
         try {
             StandardUsernameCredentials credentials = context.getCredentials();
+            // Prevent publication with unsupported credential types
+            switch (credentials.getClass().getSimpleName()) {
+                case "GitHubAppCredentials":
+                case "VaultUsernamePasswordCredentialImpl":
+                    break;
+                default:
+                    return;
+            }
+
             String apiUri = null;
             if (credentials instanceof GitHubAppCredentials) {
                 apiUri = ((GitHubAppCredentials) credentials).getApiUri();


### PR DESCRIPTION
fixes: #347

## What changed?

Unsupported credential types are now explicitly made incompatible with the `github-checks-plugin` to avoid downstream unexpected exceptions such as the one reported [here](https://github.com/jenkinsci/github-checks-plugin/pull/341#issuecomment-1621683408).

With this change, the supported credential types are:
* `GitHubAppCredentials`
*  `VaultUsernamePasswordCredentialImpl`

If an unsupported credential type is provided, an early `return` is done to avoid having to handle downstream exceptions caused by incompatible types. This means that all pipeline console log entries will be **suppressed** if the pipeline has not been configured with compatible credentials.

### Testing done

Procedure
As extracted from [here](https://github.com/jenkinsci/github-checks-plugin/blob/master/.github/workflows/maven.yml#L31), I have ran the following command to both build & run the test suite:

$ mvn -Penable-jacoco clean verify -B -V -ntp

A regression test was also carried out in our internal Jenkins controller to assert that previous functionality based on the above described credential types is left unaffected.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
