### PR TITLE
[#393] Re-enable skipped conclusion

### DIFF
--- a/src/main/java/io/jenkins/plugins/checks/github/GitHubChecksDetails.java
+++ b/src/main/java/io/jenkins/plugins/checks/github/GitHubChecksDetails.java
@@ -129,7 +129,8 @@ class GitHubChecksDetails {
     @SuppressWarnings("PMD.CyclomaticComplexity")
     public Optional<Conclusion> getConclusion() {
         switch (details.getConclusion()) {
-            case SKIPPED: // SKIPPED doesn't work for GitHub, though documented
+            case SKIPPED:
+                return Optional.of(Conclusion.SKIPPED);
             case FAILURE:
             case CANCELED: // TODO use CANCELLED if https://github.com/github/feedback/discussions/10255 is fixed
             case TIME_OUT: // TODO TIMED_OUT as above


### PR DESCRIPTION
Fixed #393.

### Testing done

Tested creating a check run with the SKIPPED conclusion which just works: https://github.com/beikov/hibernate-github-bot-test/runs/27508834193

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
