### PR TITLE
Support GitHubAppCredentials owner inference when specified on a pipeline using GitHub SCM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
-    <jenkins.version>2.361.4</jenkins.version>
+    <jenkins.version>2.440.3</jenkins.version>
     <useBeta>true</useBeta>
   </properties>
 
@@ -41,10 +41,16 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.361.x</artifactId>
-        <version>2102.v854b_fec19c92</version>
+        <artifactId>bom-2.440.x</artifactId>
+        <version>3276.vcd71db_867fb_2</version>
         <scope>import</scope>
         <type>pom</type>
+      </dependency>
+      <dependency>
+        <!-- TODO remove when available in bom-2.440.x -->
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>github-branch-source</artifactId>
+        <version>1797.v86fdb_4d57d43</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/src/main/java/io/jenkins/plugins/checks/github/GitHubChecksContext.java
+++ b/src/main/java/io/jenkins/plugins/checks/github/GitHubChecksContext.java
@@ -8,7 +8,6 @@ import org.apache.commons.lang3.StringUtils;
 import edu.hm.hafner.util.FilteredLog;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 
-import org.jenkinsci.plugins.github_branch_source.GitHubAppCredentials;
 import hudson.model.Job;
 import hudson.model.Run;
 

--- a/src/main/java/io/jenkins/plugins/checks/github/GitHubChecksPublisher.java
+++ b/src/main/java/io/jenkins/plugins/checks/github/GitHubChecksPublisher.java
@@ -127,9 +127,9 @@ public class GitHubChecksPublisher extends ChecksPublisher {
     @VisibleForTesting
     GHCheckRunBuilder getCreator(final GitHub gitHub, final GitHubChecksDetails details) throws IOException {
         GHCheckRunBuilder builder = gitHub.getRepository(context.getRepository())
-        .createCheckRun(details.getName(), context.getHeadSha())
-        .withStartedAt(details.getStartedAt().orElse(Date.from(Instant.now())));
-        
+            .createCheckRun(details.getName(), context.getHeadSha())
+            .withStartedAt(details.getStartedAt().orElse(Date.from(Instant.now())));
+
         return applyDetails(builder, details);
     }
 

--- a/src/main/java/io/jenkins/plugins/checks/github/GitHubChecksPublisher.java
+++ b/src/main/java/io/jenkins/plugins/checks/github/GitHubChecksPublisher.java
@@ -75,7 +75,12 @@ public class GitHubChecksPublisher extends ChecksPublisher {
 
             String apiUri = null;
             if (credentials instanceof GitHubAppCredentials) {
-                apiUri = ((GitHubAppCredentials) credentials).getApiUri();
+                final var gitHubAppCredentials = (GitHubAppCredentials) credentials;
+                apiUri = gitHubAppCredentials.getApiUri();
+                if (context instanceof GitHubSCMSourceChecksContext) {
+                    final var gitHubSCMSourceChecksContext = (GitHubSCMSourceChecksContext) context;
+                    credentials = gitHubAppCredentials.withOwner(gitHubSCMSourceChecksContext.getOwner());
+                }
             }
 
             GitHub gitHub = Connector.connect(StringUtils.defaultIfBlank(apiUri, gitHubUrl),

--- a/src/main/java/io/jenkins/plugins/checks/github/GitHubSCMSourceChecksContext.java
+++ b/src/main/java/io/jenkins/plugins/checks/github/GitHubSCMSourceChecksContext.java
@@ -66,6 +66,10 @@ class GitHubSCMSourceChecksContext extends GitHubChecksContext {
         }
     }
 
+    String getOwner() {
+        return Optional.ofNullable(resolveSource()).map(GitHubSCMSource::getRepoOwner).orElse(null);
+    }
+
     @Override
     public boolean isValid(final FilteredLog logger) {
         logger.logError("Trying to resolve checks parameters from GitHub SCM...");

--- a/src/test/java/io/jenkins/plugins/checks/github/GitHubChecksPublisherITest.java
+++ b/src/test/java/io/jenkins/plugins/checks/github/GitHubChecksPublisherITest.java
@@ -66,6 +66,9 @@ import io.jenkins.plugins.util.PluginLogger;
 
 import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.*;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 /**
@@ -324,6 +327,15 @@ public class GitHubChecksPublisherITest {
                     new PluginLogger(j.createTaskListener().getLogger(), "GitHub Checks"),
                     "https://github.example.com/"
             );
+
+            // Check that the owner is passed from context to credentials
+            if (context instanceof GitHubSCMSourceChecksContext) {
+                var credentials = publisher.getCredentials();
+                if (credentials instanceof GitHubAppCredentials) {
+                    var gitHubAppCredentials = (GitHubAppCredentials) credentials;
+                    assertThat(gitHubAppCredentials.getOwner()).isEqualTo("XiongKezhi");
+                }
+            }
 
             assertThat(context.getId(checksName1)).isNotPresent();
             assertThat(context.getId(checksName2)).isNotPresent();


### PR DESCRIPTION
GitHub App installed in multiple organizations get:
```
java.lang.IllegalArgumentException: Found multiple installations for GitHub app ID X but none match credential owner "". Set the right owner in the credential advanced options to one of: Y, Z
        at PluginClassLoader for github-branch-source//org.jenkinsci.plugins.github_branch_source.GitHubAppCredentials.generateAppInstallationToken(GitHubAppCredentials.java:244)
        at PluginClassLoader for github-branch-source//org.jenkinsci.plugins.github_branch_source.GitHubAppCredentials.getToken(GitHubAppCredentials.java:295)
        at PluginClassLoader for github-branch-source//org.jenkinsci.plugins.github_branch_source.GitHubAppCredentials$CredentialsTokenProvider.getEncodedAuthorization(GitHubAppCredentials.java:199)
        at PluginClassLoader for github-api//org.kohsuke.github.GitHubClient.prepareConnectorRequest(GitHubClient.java:616)
        at PluginClassLoader for github-api//org.kohsuke.github.GitHubClient.sendRequest(GitHubClient.java:455)
        at PluginClassLoader for github-api//org.kohsuke.github.GitHubClient.fetch(GitHubClient.java:159)
        at PluginClassLoader for github-api//org.kohsuke.github.GitHubClient.checkApiUrlValidity(GitHubClient.java:390)
        at PluginClassLoader for github-api//org.kohsuke.github.GitHub.checkApiUrlValidity(GitHub.java:1321)
        at PluginClassLoader for github-branch-source//org.jenkinsci.plugins.github_branch_source.ApiRateLimitChecker.verifyConnection(ApiRateLimitChecker.java:194)
        at PluginClassLoader for github-branch-source//org.jenkinsci.plugins.github_branch_source.Connector$GitHubConnection.verifyConnection(Connector.java:723)
        at PluginClassLoader for github-branch-source//org.jenkinsci.plugins.github_branch_source.Connector.connect(Connector.java:420)
        at PluginClassLoader for github-checks//io.jenkins.plugins.checks.github.GitHubChecksPublisher.publish(GitHubChecksPublisher.java:89)
        at PluginClassLoader for checks-api//io.jenkins.plugins.checks.status.BuildStatusChecksPublisher.publish(BuildStatusChecksPublisher.java:64)
        at PluginClassLoader for checks-api//io.jenkins.plugins.checks.status.BuildStatusChecksPublisher$JobCompletedListener.lambda$onCompleted$0(BuildStatusChecksPublisher.java:188)
        at java.base/java.util.Optional.ifPresent(Optional.java:178)
        at PluginClassLoader for checks-api//io.jenkins.plugins.checks.status.BuildStatusChecksPublisher$JobCompletedListener.onCompleted(BuildStatusChecksPublisher.java:188)
        at hudson.model.listeners.RunListener.lambda$fireCompleted$0(RunListener.java:223)
        at jenkins.util.Listeners.lambda$notify$0(Listeners.java:59)
        at jenkins.util.Listeners.notify(Listeners.java:67)
        at hudson.model.listeners.RunListener.fireCompleted(RunListener.java:221)
        at PluginClassLoader for workflow-job//org.jenkinsci.plugins.workflow.job.WorkflowRun.finish(WorkflowRun.java:645)
        at PluginClassLoader for workflow-job//org.jenkinsci.plugins.workflow.job.WorkflowRun$GraphL.onNewHead(WorkflowRun.java:1068)
        at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.notifyListeners(CpsFlowExecution.java:1582)
        at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsThreadGroup$3.run(CpsThreadGroup.java:512)
        at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsVmExecutorService.lambda$wrap$2(CpsVmExecutorService.java:85)
        at hudson.remoting.SingleLaneExecutorService$1.run(SingleLaneExecutorService.java:139)
        at jenkins.util.ContextResettingExecutorService$1.run(ContextResettingExecutorService.java:28)
        at jenkins.security.ImpersonatingExecutorService$1.run(ImpersonatingExecutorService.java:68)
        at jenkins.util.ErrorLoggingExecutorService.lambda$wrap$0(ErrorLoggingExecutorService.java:51)
        at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
        at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsVmExecutorService$1.call(CpsVmExecutorService.java:53)
        at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsVmExecutorService$1.call(CpsVmExecutorService.java:50)
        at org.codehaus.groovy.runtime.GroovyCategorySupport$ThreadCategoryInfo.use(GroovyCategorySupport.java:136)
        at org.codehaus.groovy.runtime.GroovyCategorySupport.use(GroovyCategorySupport.java:275)
        at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsVmExecutorService.lambda$categoryThreadFactory$0(CpsVmExecutorService.java:50)
        at java.base/java.lang.Thread.run(Thread.java:840)
```

Steps to reproduce:

* install GitHub App in more than one organization
* configure GitHub App Credentials with owner left blank to infer value
* configure multi branch pipeline using GitHub branch source
* trigger build

This fixes the issue by explicitly setting `owner` on contextualized credentials. This also needs https://github.com/jenkinsci/github-branch-source-plugin/pull/803 to make it work. I manually tested this PR with `github-branch-source-plugin` snapshot. The owner is inferred as expected and the build runs without any exception.