### PR TITLE
Require Jenkins 2.479.1 and Jakarta EE 9

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        java: [11]
+        java: [17]
         os: [ubuntu-latest]
 
     runs-on: ${{ matrix.os }}

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.88</version>
+    <version>5.7</version>
     <relativePath/>
   </parent>
 
@@ -19,9 +19,8 @@
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-    <jenkins.baseline>2.440</jenkins.baseline>
-    <jenkins.version>${jenkins.baseline}.3</jenkins.version>
-    <useBeta>true</useBeta>
+    <jenkins.baseline>2.479</jenkins.baseline>
+    <jenkins.version>${jenkins.baseline}.1</jenkins.version>
   </properties>
 
   <licenses>
@@ -44,15 +43,9 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-${jenkins.baseline}.x</artifactId>
-        <version>3413.v0d896b_76a_30d</version>
+        <version>4051.v78dce3ce8b_d6</version>
         <scope>import</scope>
         <type>pom</type>
-      </dependency>
-      <dependency>
-        <!-- TODO remove when available in bom-2.440.x -->
-        <groupId>org.jenkins-ci.plugins</groupId>
-        <artifactId>github-branch-source</artifactId>
-        <version>1807.v50351eb_7dd13</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -94,7 +87,7 @@
     <dependency>
       <groupId>org.wiremock</groupId>
       <artifactId>wiremock-standalone</artifactId>
-      <version>3.0.1</version>
+      <version>3.10.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/java/io/jenkins/plugins/checks/github/CheckRunGHEventSubscriber.java
+++ b/src/main/java/io/jenkins/plugins/checks/github/CheckRunGHEventSubscriber.java
@@ -5,7 +5,6 @@ import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 import java.util.logging.Level;
@@ -74,7 +73,7 @@ public class CheckRunGHEventSubscriber extends GHEventsSubscriber {
 
     @Override
     protected Set<GHEvent> events() {
-        return Collections.unmodifiableSet(new HashSet<>(Collections.singletonList(GHEvent.CHECK_RUN)));
+        return Set.copyOf(Collections.singletonList(GHEvent.CHECK_RUN));
     }
 
     @Override
@@ -92,7 +91,7 @@ public class CheckRunGHEventSubscriber extends GHEventsSubscriber {
             JSONObject payloadJSON = new JSONObject(payload);
 
             LOGGER.log(Level.INFO, "Received rerun request through GitHub checks API.");
-            try (ACLContext ignored = ACL.as(ACL.SYSTEM)) {
+            try (ACLContext ignored = ACL.as2(ACL.SYSTEM2)) {
                 String branchName = payloadJSON.getJSONObject("check_run").getJSONObject("check_suite").optString("head_branch");
                 scheduleRerun(checkRun, branchName);
             }

--- a/src/main/java/io/jenkins/plugins/checks/github/GitHubChecksContext.java
+++ b/src/main/java/io/jenkins/plugins/checks/github/GitHubChecksContext.java
@@ -126,7 +126,7 @@ public abstract class GitHubChecksContext {
     protected abstract Optional<Run<?, ?>> getRun();
 
     private Optional<GitHubChecksAction> getAction(final String name) {
-        if (!getRun().isPresent()) {
+        if (getRun().isEmpty()) {
             return Optional.empty();
         }
         return getRun().get().getActions(GitHubChecksAction.class)
@@ -136,11 +136,11 @@ public abstract class GitHubChecksContext {
     }
 
     void addActionIfMissing(final long id, final String name) {
-        if (!getRun().isPresent()) {
+        if (getRun().isEmpty()) {
             return;
         }
         Optional<GitHubChecksAction> action = getAction(name);
-        if (!action.isPresent()) {
+        if (action.isEmpty()) {
             getRun().get().addAction(new GitHubChecksAction(id, name));
         }
     }

--- a/src/main/java/io/jenkins/plugins/checks/github/GitHubChecksDetails.java
+++ b/src/main/java/io/jenkins/plugins/checks/github/GitHubChecksDetails.java
@@ -74,17 +74,11 @@ class GitHubChecksDetails {
      * @throws IllegalArgumentException if the status of the {@code details} is not one of {@link ChecksStatus}
      */
     public Status getStatus() {
-        switch (details.getStatus()) {
-            case NONE:
-            case QUEUED:
-                return Status.QUEUED;
-            case IN_PROGRESS:
-                return Status.IN_PROGRESS;
-            case COMPLETED:
-                return Status.COMPLETED;
-            default:
-                throw new IllegalArgumentException("Unsupported checks status: " + details.getStatus());
-        }
+        return switch (details.getStatus()) {
+            case NONE, QUEUED -> Status.QUEUED;
+            case IN_PROGRESS -> Status.IN_PROGRESS;
+            case COMPLETED -> Status.COMPLETED;
+        };
     }
 
     /**
@@ -128,24 +122,16 @@ class GitHubChecksDetails {
      */
     @SuppressWarnings("PMD.CyclomaticComplexity")
     public Optional<Conclusion> getConclusion() {
-        switch (details.getConclusion()) {
-            case SKIPPED:
-                return Optional.of(Conclusion.SKIPPED);
-            case FAILURE:
-            case CANCELED: // TODO use CANCELLED if https://github.com/github/feedback/discussions/10255 is fixed
-            case TIME_OUT: // TODO TIMED_OUT as above
-                return Optional.of(Conclusion.FAILURE);
-            case NEUTRAL:
-                return Optional.of(Conclusion.NEUTRAL);
-            case SUCCESS:
-                return Optional.of(Conclusion.SUCCESS);
-            case ACTION_REQUIRED:
-                return Optional.of(Conclusion.ACTION_REQUIRED);
-            case NONE:
-                return Optional.empty();
-            default:
-                throw new IllegalArgumentException("Unsupported checks conclusion: " + details.getConclusion());
-        }
+        return switch (details.getConclusion()) {
+            case SKIPPED ->
+                    Optional.of(Conclusion.SKIPPED); // TODO use CANCELLED if https://github.com/github/feedback/discussions/10255 is fixed
+            case FAILURE, CANCELED, TIME_OUT -> // TODO TIMED_OUT as above
+                    Optional.of(Conclusion.FAILURE);
+            case NEUTRAL -> Optional.of(Conclusion.NEUTRAL);
+            case SUCCESS -> Optional.of(Conclusion.SUCCESS);
+            case ACTION_REQUIRED -> Optional.of(Conclusion.ACTION_REQUIRED);
+            case NONE -> Optional.empty();
+        };
     }
 
     /**
@@ -235,17 +221,11 @@ class GitHubChecksDetails {
     }
 
     private AnnotationLevel getAnnotationLevel(final ChecksAnnotationLevel checksLevel) {
-        switch (checksLevel) {
-            case NOTICE:
-                return AnnotationLevel.NOTICE;
-            case FAILURE:
-                return AnnotationLevel.FAILURE;
-            case WARNING:
-                return AnnotationLevel.WARNING;
-            case NONE:
-                throw new IllegalArgumentException("Annotation level is required but not set.");
-            default:
-                throw new IllegalArgumentException("Unsupported checks annotation level: " + checksLevel);
-        }
+        return switch (checksLevel) {
+            case NOTICE -> AnnotationLevel.NOTICE;
+            case FAILURE -> AnnotationLevel.FAILURE;
+            case WARNING -> AnnotationLevel.WARNING;
+            case NONE -> throw new IllegalArgumentException("Annotation level is required but not set.");
+        };
     }
 }

--- a/src/main/java/io/jenkins/plugins/checks/github/GitSCMChecksContext.java
+++ b/src/main/java/io/jenkins/plugins/checks/github/GitSCMChecksContext.java
@@ -136,7 +136,7 @@ class GitSCMChecksContext extends GitHubChecksContext {
     public boolean isValid(final FilteredLog logger) {
         logger.logError("Trying to resolve checks parameters from Git SCM...");
 
-        if (!getScmFacade().findGitSCM(run).isPresent()) {
+        if (getScmFacade().findGitSCM(run).isEmpty()) {
             logger.logError("Job does not use Git SCM");
 
             return false;

--- a/src/test/java/io/jenkins/plugins/checks/github/CheckRunGHEventSubscriberTest.java
+++ b/src/test/java/io/jenkins/plugins/checks/github/CheckRunGHEventSubscriberTest.java
@@ -74,10 +74,8 @@ class CheckRunGHEventSubscriberTest {
     @Test
     void shouldThrowExceptionWhenCheckSuitesMissingFromPayload() throws IOException {
         assertThatThrownBy(
-            () -> {
-                new CheckRunGHEventSubscriber(mock(JenkinsFacade.class), mock(SCMFacade.class))
-                  .onEvent(createEventWithRerunRequest(RERUN_REQUEST_JSON_FOR_PR_MISSING_CHECKSUITE));
-            })
+            () -> new CheckRunGHEventSubscriber(mock(JenkinsFacade.class), mock(SCMFacade.class))
+              .onEvent(createEventWithRerunRequest(RERUN_REQUEST_JSON_FOR_PR_MISSING_CHECKSUITE)))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("Could not parse check run event:");
     }

--- a/src/test/java/io/jenkins/plugins/checks/github/GitHubChecksPublisherITest.java
+++ b/src/test/java/io/jenkins/plugins/checks/github/GitHubChecksPublisherITest.java
@@ -2,6 +2,7 @@ package io.jenkins.plugins.checks.github;
 
 import com.cloudbees.plugins.credentials.CredentialsMatchers;
 import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import hudson.model.Action;
@@ -30,7 +31,6 @@ import com.fasterxml.jackson.databind.InjectableValues;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.introspect.VisibilityChecker;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -66,9 +66,6 @@ import io.jenkins.plugins.util.PluginLogger;
 
 import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.*;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 /**
@@ -284,7 +281,7 @@ public class GitHubChecksPublisherITest {
         mapper.setVisibility(new VisibilityChecker.Std(NONE, NONE, NONE, NONE, ANY));
         mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
         mapper.configure(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS, true);
-        mapper.setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE);
+        mapper.setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
 
         InjectableValues.Std std = new InjectableValues.Std();
         std.addValue("org.kohsuke.github.connector.GitHubConnectorResponse", null);
@@ -344,8 +341,7 @@ public class GitHubChecksPublisherITest {
             // Check that the owner is passed from context to credentials
             if (context instanceof GitHubSCMSourceChecksContext) {
                 var credentials = publisher.getContext().getCredentials();
-                if (credentials instanceof GitHubAppCredentials) {
-                    var gitHubAppCredentials = (GitHubAppCredentials) credentials;
+                if (credentials instanceof GitHubAppCredentials gitHubAppCredentials) {
                     assertThat(gitHubAppCredentials.getOwner()).isEqualTo("XiongKezhi");
                 }
             }

--- a/src/test/java/io/jenkins/plugins/checks/github/GitSCMChecksContextITest.java
+++ b/src/test/java/io/jenkins/plugins/checks/github/GitSCMChecksContextITest.java
@@ -39,10 +39,10 @@ public class GitSCMChecksContextITest {
     @Test
     public void shouldRetrieveContextFromFreeStyleBuild() throws Exception {
         FreeStyleProject job = j.createFreeStyleProject();
-        
+
         BranchSpec branchSpec = new BranchSpec(EXISTING_HASH);
         GitSCM scm = new GitSCM(GitSCM.createRepoList(HTTP_URL, CREDENTIALS_ID),
-                Collections.singletonList(branchSpec), false, Collections.emptyList(), 
+                Collections.singletonList(branchSpec),
                 null, null, Collections.emptyList());
         job.setScm(scm);
 
@@ -61,28 +61,28 @@ public class GitSCMChecksContextITest {
 
     /**
      * Creates a pipeline that uses {@link hudson.plugins.git.GitSCM} and runs a successful build.
-     * Then this build is used to create a new {@link GitSCMChecksContext}. 
+     * Then this build is used to create a new {@link GitSCMChecksContext}.
      */
-    @Test 
+    @Test
     public void shouldRetrieveContextFromPipeline() throws Exception {
         WorkflowJob job = j.createProject(WorkflowJob.class);
-        
-        job.setDefinition(new CpsFlowDefinition("node {\n" 
-                + "  stage ('Checkout') {\n" 
+
+        job.setDefinition(new CpsFlowDefinition("node {\n"
+                + "  stage ('Checkout') {\n"
                 + "    checkout scm: ([\n"
                 + "                    $class: 'GitSCM',\n"
                 + "                    userRemoteConfigs: [[credentialsId: '" + CREDENTIALS_ID + "', url: '" + HTTP_URL + "']],\n"
                 + "                    branches: [[name: '" + EXISTING_HASH + "']]\n"
                 + "            ])"
-                + "  }\n" 
+                + "  }\n"
                 + "}\n", true));
-        
+
         Run<?, ?> run = buildSuccessfully(job);
 
         GitSCMChecksContext gitSCMChecksContext = new GitSCMChecksContext(run, URL_NAME);
 
         assertThat(gitSCMChecksContext.getRepository()).isEqualTo("jenkinsci/github-checks-plugin");
         assertThat(gitSCMChecksContext.getCredentialsId()).isEqualTo(CREDENTIALS_ID);
-        assertThat(gitSCMChecksContext.getHeadSha()).isEqualTo(EXISTING_HASH); 
+        assertThat(gitSCMChecksContext.getHeadSha()).isEqualTo(EXISTING_HASH);
     }
 }

--- a/src/test/java/io/jenkins/plugins/checks/github/config/GitHubChecksConfigITest.java
+++ b/src/test/java/io/jenkins/plugins/checks/github/config/GitHubChecksConfigITest.java
@@ -7,6 +7,8 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+
 import org.jvnet.hudson.test.JenkinsRule;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -26,7 +28,7 @@ public class GitHubChecksConfigITest {
     @Test
     public void shouldUseDefaultConfigWhenNoSCM() throws IOException {
         ByteArrayOutputStream os = new ByteArrayOutputStream();
-        GitHubChecksPublisherFactory.fromJob(j.createFreeStyleProject(), new StreamTaskListener(os));
+        GitHubChecksPublisherFactory.fromJob(j.createFreeStyleProject(), new StreamTaskListener(os, StandardCharsets.UTF_8));
 
         assertThat(os.toString()).doesNotContain("Causes for no suitable publisher found: ");
     }


### PR DESCRIPTION
## Require Jenkins 2.479.1 and Jakarta EE 9

Jenkins 2.479.1 provides Jakarta EE 9, Eclipse Jetty 12, Spring Security 6, and Java 17.

* Update plugin pom and baseline
* Remove deprecations
* Use Java 17 language features

### Testing done

Confirmed that tests pass.

### Submitter checklist
* [x]  Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
* [x]  Ensure that the pull request title represents the desired changelog entry
* [x]  Please describe what you did
* [x]  Link to relevant issues in GitHub or Jira
* [x]  Link to relevant pull requests, esp. upstream and downstream changes
* [x]  Ensure you have provided tests - that demonstrates feature works or fixes the issue
