### PR TITLE
Add disable toggle and user required role configuration for rerun action

### DIFF
--- a/src/main/java/io/jenkins/plugins/checks/github/status/GitHubSCMSourceStatusChecksTrait.java
+++ b/src/main/java/io/jenkins/plugins/checks/github/status/GitHubSCMSourceStatusChecksTrait.java
@@ -30,6 +30,8 @@ public class GitHubSCMSourceStatusChecksTrait extends SCMSourceTrait implements 
     private String name = "Jenkins";
     private boolean suppressLogs = false;
     private boolean skipProgressUpdates = false;
+    private String rerunActionRole = "";
+    private boolean disableRerunAction = false;
 
     /**
      * Constructor for stapler.
@@ -80,9 +82,20 @@ public class GitHubSCMSourceStatusChecksTrait extends SCMSourceTrait implements 
     }
 
     @Override
+    public String getRerunActionRole() {
+        return rerunActionRole;
+    }
+
+    @Override
+    public boolean isDisableRerunAction() {
+        return disableRerunAction;
+    }
+
+    @Override
     public boolean isSkipProgressUpdates() {
         return skipProgressUpdates;
     }
+    
 
     @DataBoundSetter
     public void setSkipProgressUpdates(final boolean skipProgressUpdates) {
@@ -124,6 +137,16 @@ public class GitHubSCMSourceStatusChecksTrait extends SCMSourceTrait implements 
     @DataBoundSetter
     public void setSuppressLogs(final boolean suppressLogs) {
         this.suppressLogs = suppressLogs;
+    }
+
+    @DataBoundSetter
+    public void setRerunActionRole(final String rerunActionRole) {
+        this.rerunActionRole = rerunActionRole;
+    }
+
+    @DataBoundSetter
+    public void setDisableRerunAction(final boolean disableRerunAction) {
+        this.disableRerunAction = disableRerunAction;
     }
 
     @Override

--- a/src/main/java/io/jenkins/plugins/checks/github/status/GitHubStatusChecksConfigurations.java
+++ b/src/main/java/io/jenkins/plugins/checks/github/status/GitHubStatusChecksConfigurations.java
@@ -33,6 +33,20 @@ public interface GitHubStatusChecksConfigurations {
     boolean isSuppressLogs();
 
     /**
+     * Defines whether a role is required to use the rerun action.
+     *
+     * @return the name of the role
+     */
+    String getRerunActionRole();
+
+    /**
+     * Defines whether to disable rerun action.
+     *
+     * @return true to disable rerun action
+     */
+    boolean isDisableRerunAction();
+
+    /**
      * Returns whether to suppress progress updates from the {@code io.jenkins.plugins.checks.status.FlowExecutionAnalyzer}.
      * Queued, Checkout and Completed will still run but not 'onNewHead'
      *
@@ -59,6 +73,16 @@ class DefaultGitHubStatusChecksConfigurations implements GitHubStatusChecksConfi
 
     @Override
     public boolean isSuppressLogs() {
+        return false;
+    }
+
+    @Override
+    public String getRerunActionRole() {
+        return "";
+    }
+
+    @Override
+    public boolean isDisableRerunAction() {
         return false;
     }
 

--- a/src/main/java/io/jenkins/plugins/checks/github/status/GitHubStatusChecksProperties.java
+++ b/src/main/java/io/jenkins/plugins/checks/github/status/GitHubStatusChecksProperties.java
@@ -64,6 +64,14 @@ public class GitHubStatusChecksProperties extends AbstractStatusChecksProperties
         return getConfigurations(job).orElse(DEFAULT_CONFIGURATION).isSuppressLogs();
     }
 
+    public String getRerunActionRole(final Job<?, ?> job) {
+        return getConfigurations(job).orElse(DEFAULT_CONFIGURATION).getRerunActionRole();
+    }
+
+    public boolean isDisableRerunAction(final Job<?, ?> job) {
+        return getConfigurations(job).orElse(DEFAULT_CONFIGURATION).isDisableRerunAction();
+    }
+
     @Override
     public boolean isSkipProgressUpdates(final Job<?, ?> job) {
         return getConfigurations(job).orElse(DEFAULT_CONFIGURATION).isSkipProgressUpdates();

--- a/src/main/java/io/jenkins/plugins/checks/github/status/GitSCMStatusChecksExtension.java
+++ b/src/main/java/io/jenkins/plugins/checks/github/status/GitSCMStatusChecksExtension.java
@@ -22,6 +22,8 @@ public class GitSCMStatusChecksExtension extends GitSCMExtension implements GitH
     private String name = "Jenkins";
     private boolean suppressLogs;
     private boolean skipProgressUpdates = false;
+    private String rerunActionRole = "";
+    private boolean disableRerunAction = false;
 
     /**
      * Constructor for stapler.
@@ -49,6 +51,16 @@ public class GitSCMStatusChecksExtension extends GitSCMExtension implements GitH
     @Override
     public boolean isSuppressLogs() {
         return suppressLogs;
+    }
+
+    @Override
+    public String getRerunActionRole() {
+        return rerunActionRole;
+    }
+
+    @Override
+    public boolean isDisableRerunAction() {
+        return disableRerunAction;
     }
 
     @Override
@@ -91,6 +103,16 @@ public class GitSCMStatusChecksExtension extends GitSCMExtension implements GitH
     @DataBoundSetter
     public void setSuppressLogs(final boolean suppressLogs) {
         this.suppressLogs = suppressLogs;
+    }
+
+    @DataBoundSetter
+    public void setRerunActionRole(final String rerunActionRole) {
+        this.rerunActionRole = rerunActionRole;
+    }
+
+    @DataBoundSetter
+    public void setDisableRerunAction(final boolean disableRerunAction) {
+        this.disableRerunAction = disableRerunAction;
     }
 
     /**

--- a/src/main/resources/io/jenkins/plugins/checks/github/status/GitHubSCMSourceStatusChecksTrait/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/checks/github/status/GitHubSCMSourceStatusChecksTrait/config.jelly
@@ -7,4 +7,12 @@
     <f:checkbox/>
   </f:entry>
 
+  <f:entry title="${%User role required for rerun action}" field="rerunActionRole">
+    <f:textbox/>
+  </f:entry>
+
+  <f:entry title="Disable rerun action" field="disableRerunAction">
+    <f:checkbox/>
+  </f:entry>
+
 </j:jelly>

--- a/src/main/resources/io/jenkins/plugins/checks/github/status/GitSCMStatusChecksExtension/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/checks/github/status/GitSCMStatusChecksExtension/config.jelly
@@ -1,6 +1,14 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:g="/lib/github-checks/status">
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:g="/lib/github-checks/status">
 
   <g:properties/>
+
+  <f:entry title="${%User role required for rerun action}" field="rerunActionRole">
+    <f:textbox/>
+  </f:entry>
+
+  <f:entry title="Disable rerun action" field="disableRerunAction">
+    <f:checkbox/>
+  </f:entry>
 
 </j:jelly>

--- a/src/test/java/io/jenkins/plugins/checks/github/CheckRunGHEventSubscriberTest.java
+++ b/src/test/java/io/jenkins/plugins/checks/github/CheckRunGHEventSubscriberTest.java
@@ -5,7 +5,9 @@ import hudson.model.Job;
 import hudson.model.ParametersAction;
 import hudson.model.Run;
 import hudson.model.StringParameterValue;
+import hudson.model.User;
 import io.jenkins.plugins.util.JenkinsFacade;
+import io.jenkins.plugins.checks.github.status.GitHubStatusChecksProperties;
 import org.apache.commons.io.FileUtils;
 import org.jenkinsci.plugins.github.extension.GHSubscriberEvent;
 import org.jenkinsci.plugins.github_branch_source.GitHubSCMSource;
@@ -18,11 +20,16 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 import java.util.logging.Level;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import org.mockito.MockedStatic;
+import static org.mockito.Mockito.mockStatic;
 
 class CheckRunGHEventSubscriberTest {
 
@@ -37,10 +44,11 @@ class CheckRunGHEventSubscriberTest {
         JenkinsFacade jenkinsFacade = mock(JenkinsFacade.class);
         SCMFacade scmFacade = mock(SCMFacade.class);
         GitHubSCMSource source = mock(GitHubSCMSource.class);
+        GitHubStatusChecksProperties githubStatusChecksProperties = mock(GitHubStatusChecksProperties.class);
 
         when(scmFacade.findGitHubSCMSource(job)).thenReturn(Optional.of(source));
 
-        assertThat(new CheckRunGHEventSubscriber(jenkinsFacade, scmFacade).isApplicable(job))
+        assertThat(new CheckRunGHEventSubscriber(jenkinsFacade, scmFacade, githubStatusChecksProperties).isApplicable(job))
                 .isTrue();
     }
 
@@ -66,7 +74,7 @@ class CheckRunGHEventSubscriberTest {
     @Test
     void shouldProcessCheckRunEventWithRerequestedAction() throws IOException {
         try (LogRecorder logRecorder = new LogRecorder().record(CheckRunGHEventSubscriber.class.getName(), Level.INFO).capture(1)) {
-            new CheckRunGHEventSubscriber(mock(JenkinsFacade.class), mock(SCMFacade.class))
+            new CheckRunGHEventSubscriber(mock(JenkinsFacade.class), mock(SCMFacade.class), mock(GitHubStatusChecksProperties.class))
                     .onEvent(createEventWithRerunRequest(RERUN_REQUEST_JSON_FOR_PR));
             assertThat(logRecorder.getMessages().get(0)).contains("Received rerun request through GitHub checks API.");
         }
@@ -75,7 +83,7 @@ class CheckRunGHEventSubscriberTest {
     @Test
     void shouldThrowExceptionWhenCheckSuitesMissingFromPayload() {
         assertThatThrownBy(
-                () -> new CheckRunGHEventSubscriber(mock(JenkinsFacade.class), mock(SCMFacade.class))
+                () -> new CheckRunGHEventSubscriber(mock(JenkinsFacade.class), mock(SCMFacade.class), mock(GitHubStatusChecksProperties.class))
                         .onEvent(createEventWithRerunRequest(RERUN_REQUEST_JSON_FOR_PR_MISSING_CHECKSUITE)))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("Could not parse check run event:");
@@ -84,7 +92,7 @@ class CheckRunGHEventSubscriberTest {
     @Test
     void shouldIgnoreHeadBranchMissingFromPayload() throws IOException {
         try (LogRecorder logRecorder = new LogRecorder().record(CheckRunGHEventSubscriber.class.getName(), Level.INFO).capture(1)) {
-            new CheckRunGHEventSubscriber(mock(JenkinsFacade.class), mock(SCMFacade.class))
+            new CheckRunGHEventSubscriber(mock(JenkinsFacade.class), mock(SCMFacade.class), mock(GitHubStatusChecksProperties.class))
                     .onEvent(createEventWithRerunRequest(RERUN_REQUEST_JSON_FOR_PR_MISSING_CHECKSUITE_HEAD_BRANCH));
             assertThat(logRecorder.getMessages().get(0)).contains("Received rerun request through GitHub checks API.");
         }
@@ -93,7 +101,7 @@ class CheckRunGHEventSubscriberTest {
     @Test
     void shouldIgnoreCheckRunEventWithoutRerequestedAction() throws IOException {
         try (LogRecorder logRecorder = new LogRecorder().record(CheckRunGHEventSubscriber.class.getName(), Level.FINE).capture(1)) {
-            new CheckRunGHEventSubscriber(mock(JenkinsFacade.class), mock(SCMFacade.class))
+            new CheckRunGHEventSubscriber(mock(JenkinsFacade.class), mock(SCMFacade.class), mock(GitHubStatusChecksProperties.class))
                     .onEvent(createEventWithRerunRequest("check-run-event-with-created-action.json"));
             assertThat(logRecorder.getMessages()).contains("Unsupported check run action: created");
         }
@@ -105,6 +113,7 @@ class CheckRunGHEventSubscriberTest {
         Run run = mock(Run.class);
         JenkinsFacade jenkinsFacade = mock(JenkinsFacade.class);
         SCMFacade scmFacade = mock(SCMFacade.class);
+        GitHubStatusChecksProperties githubStatusChecksProperties = mock(GitHubStatusChecksProperties.class);
 
         when(jenkinsFacade.getBuild("codingstyle/PR-1#2")).thenReturn(Optional.of(run));
         when(jenkinsFacade.getFullNameOf(job)).thenReturn("codingstyle/PR-1");
@@ -114,9 +123,11 @@ class CheckRunGHEventSubscriberTest {
         );
         when(job.getNextBuildNumber()).thenReturn(1);
         when(job.getName()).thenReturn("PR-1");
+        when(githubStatusChecksProperties.getRerunActionRole(job)).thenReturn("");
+        when(githubStatusChecksProperties.isDisableRerunAction(job)).thenReturn(false);
 
         try (LogRecorder logRecorder = new LogRecorder().record(CheckRunGHEventSubscriber.class.getName(), Level.INFO).capture(1)) {
-            new CheckRunGHEventSubscriber(jenkinsFacade, scmFacade)
+            new CheckRunGHEventSubscriber(jenkinsFacade, scmFacade, githubStatusChecksProperties)
                     .onEvent(createEventWithRerunRequest(RERUN_REQUEST_JSON_FOR_PR));
             assertThat(logRecorder.getMessages())
                     .contains("Scheduled rerun (build #1) for job codingstyle/PR-1, requested by XiongKezhi");
@@ -129,6 +140,7 @@ class CheckRunGHEventSubscriberTest {
         Run run = mock(Run.class);
         JenkinsFacade jenkinsFacade = mock(JenkinsFacade.class);
         SCMFacade scmFacade = mock(SCMFacade.class);
+        GitHubStatusChecksProperties githubStatusChecksProperties = mock(GitHubStatusChecksProperties.class);
 
         when(jenkinsFacade.getBuild("codingstyle/master#8")).thenReturn(Optional.of(run));
         when(jenkinsFacade.getFullNameOf(job)).thenReturn("codingstyle/master");
@@ -136,9 +148,11 @@ class CheckRunGHEventSubscriberTest {
         when(run.getAction(ParametersAction.class)).thenReturn(null);
         when(job.getNextBuildNumber()).thenReturn(1);
         when(job.getName()).thenReturn("master");
+        when(githubStatusChecksProperties.getRerunActionRole(job)).thenReturn("");
+        when(githubStatusChecksProperties.isDisableRerunAction(job)).thenReturn(false);
 
         try (LogRecorder logRecorder = new LogRecorder().record(CheckRunGHEventSubscriber.class.getName(), Level.INFO).capture(1)) {
-            new CheckRunGHEventSubscriber(jenkinsFacade, scmFacade)
+            new CheckRunGHEventSubscriber(jenkinsFacade, scmFacade, githubStatusChecksProperties)
                     .onEvent(createEventWithRerunRequest(RERUN_REQUEST_JSON_FOR_MASTER));
             assertThat(logRecorder.getMessages())
                     .contains("Scheduled rerun (build #1) for job codingstyle/master, requested by XiongKezhi");
@@ -150,8 +164,94 @@ class CheckRunGHEventSubscriberTest {
         JenkinsFacade jenkinsFacade = mock(JenkinsFacade.class);
         when(jenkinsFacade.getBuild("codingstyle/PR-1#2")).thenReturn(Optional.empty());
 
-        assertNoBuildIsScheduled(jenkinsFacade, mock(SCMFacade.class),
+        assertNoBuildIsScheduled(jenkinsFacade, mock(SCMFacade.class), mock(GitHubStatusChecksProperties.class),
                 createEventWithRerunRequest(RERUN_REQUEST_JSON_FOR_PR));
+    }
+
+    @Test
+    void shouldNotScheduleRerunWhenDisabled() throws IOException {
+        Job job = mock(Job.class);
+        Run run = mock(Run.class);
+        JenkinsFacade jenkinsFacade = mock(JenkinsFacade.class);
+        SCMFacade scmFacade = mock(SCMFacade.class);
+        GitHubStatusChecksProperties githubStatusChecksProperties = mock(GitHubStatusChecksProperties.class);
+
+        when(jenkinsFacade.getBuild("codingstyle/PR-1#2")).thenReturn(Optional.of(run));
+        when(jenkinsFacade.getFullNameOf(job)).thenReturn("codingstyle/PR-1");
+        when(run.getParent()).thenReturn(job);
+        when(githubStatusChecksProperties.isDisableRerunAction(job)).thenReturn(true);
+
+        try (LogRecorder logRecorder = new LogRecorder().record(CheckRunGHEventSubscriber.class.getName(), Level.INFO).capture(1)) {
+            new CheckRunGHEventSubscriber(jenkinsFacade, scmFacade, githubStatusChecksProperties)
+                    .onEvent(createEventWithRerunRequest(RERUN_REQUEST_JSON_FOR_PR));
+            assertThat(logRecorder.getMessages())
+                    .contains("Rerun action is disabled for job codingstyle/PR-1");
+        }
+    }
+
+    @Test
+    void shouldScheduleRerunWhenUserHasRequiredRole() throws IOException {
+        Job job = mock(Job.class);
+        Run run = mock(Run.class);
+        JenkinsFacade jenkinsFacade = mock(JenkinsFacade.class);
+        SCMFacade scmFacade = mock(SCMFacade.class);
+        GitHubStatusChecksProperties githubStatusChecksProperties = mock(GitHubStatusChecksProperties.class);
+        User user = mock(User.class);
+        List<String> userRoles = new ArrayList<>();
+        userRoles.add("test-role");
+
+        when(jenkinsFacade.getBuild("codingstyle/PR-1#2")).thenReturn(Optional.of(run));
+        when(jenkinsFacade.getFullNameOf(job)).thenReturn("codingstyle/PR-1");
+        when(run.getParent()).thenReturn(job);
+        when(run.getAction(ParametersAction.class)).thenReturn(
+                new ParametersAction(new StringParameterValue("test_key", "test_value"))
+        );
+        when(job.getNextBuildNumber()).thenReturn(1);
+        when(job.getName()).thenReturn("PR-1");
+        when(githubStatusChecksProperties.getRerunActionRole(job)).thenReturn("test-role");
+        when(githubStatusChecksProperties.isDisableRerunAction(job)).thenReturn(false);
+        try(MockedStatic<User> staticUser = mockStatic(User.class)) {
+            staticUser.when(() -> User.get("XiongKezhi")).thenReturn(user);
+            when(user.getAuthorities()).thenReturn(userRoles);
+            try (LogRecorder logRecorder = new LogRecorder().record(CheckRunGHEventSubscriber.class.getName(), Level.INFO).capture(1)) {
+                new CheckRunGHEventSubscriber(jenkinsFacade, scmFacade, githubStatusChecksProperties)
+                        .onEvent(createEventWithRerunRequest(RERUN_REQUEST_JSON_FOR_PR));
+                assertThat(logRecorder.getMessages())
+                        .contains("Scheduled rerun (build #1) for job codingstyle/PR-1, requested by XiongKezhi");
+            }
+        }
+    }
+
+    @Test
+    void shouldNotScheduleRerunWhenUserDoesNotHaveRequiredRole() throws IOException {
+        Job job = mock(Job.class);
+        Run run = mock(Run.class);
+        JenkinsFacade jenkinsFacade = mock(JenkinsFacade.class);
+        SCMFacade scmFacade = mock(SCMFacade.class);
+        GitHubStatusChecksProperties githubStatusChecksProperties = mock(GitHubStatusChecksProperties.class);
+        User user = mock(User.class);
+        List<String> userRoles = Collections.<String>emptyList();
+
+        when(jenkinsFacade.getBuild("codingstyle/PR-1#2")).thenReturn(Optional.of(run));
+        when(jenkinsFacade.getFullNameOf(job)).thenReturn("codingstyle/PR-1");
+        when(run.getParent()).thenReturn(job);
+        when(run.getAction(ParametersAction.class)).thenReturn(
+                new ParametersAction(new StringParameterValue("test_key", "test_value"))
+        );
+        when(job.getNextBuildNumber()).thenReturn(1);
+        when(job.getName()).thenReturn("PR-1");
+        when(githubStatusChecksProperties.getRerunActionRole(job)).thenReturn("test-role");
+        when(githubStatusChecksProperties.isDisableRerunAction(job)).thenReturn(false);
+        try(MockedStatic<User> staticUser = mockStatic(User.class)) {
+            staticUser.when(() -> User.get("XiongKezhi")).thenReturn(user);
+            when(user.getAuthorities()).thenReturn(userRoles);
+            try (LogRecorder logRecorder = new LogRecorder().record(CheckRunGHEventSubscriber.class.getName(), Level.INFO).capture(1)) {
+                new CheckRunGHEventSubscriber(jenkinsFacade, scmFacade, githubStatusChecksProperties)
+                        .onEvent(createEventWithRerunRequest(RERUN_REQUEST_JSON_FOR_PR));
+                assertThat(logRecorder.getMessages())
+                        .contains("The user XiongKezhi does not have the required test-role role for the rerun action on job codingstyle/PR-1");
+            }
+        }
     }
 
     @Test
@@ -171,9 +271,10 @@ class CheckRunGHEventSubscriberTest {
     }
 
     private static void assertNoBuildIsScheduled(final JenkinsFacade jenkinsFacade, final SCMFacade scmFacade,
+                                                 final GitHubStatusChecksProperties githubStatusChecksProperties,
                                                  final GHSubscriberEvent event) {
         try (LogRecorder logRecorder = new LogRecorder().record(CheckRunGHEventSubscriber.class.getName(), Level.WARNING).capture(1)) {
-            new CheckRunGHEventSubscriber(jenkinsFacade, scmFacade).onEvent(event);
+            new CheckRunGHEventSubscriber(jenkinsFacade, scmFacade, githubStatusChecksProperties).onEvent(event);
             assertThat(logRecorder.getMessages())
                     .contains("No build found for rerun request from repository: XiongKezhi/codingstyle and id: codingstyle/PR-1#2");
         }

--- a/src/test/java/io/jenkins/plugins/checks/github/status/GitHubStatusChecksPropertiesTest.java
+++ b/src/test/java/io/jenkins/plugins/checks/github/status/GitHubStatusChecksPropertiesTest.java
@@ -30,9 +30,11 @@ class GitHubStatusChecksPropertiesTest {
         trait.setSkip(true);
         trait.setUnstableBuildNeutral(true);
         trait.setSuppressLogs(true);
+        trait.setRerunActionRole("test-role");
+        trait.setDisableRerunAction(true);
 
         assertJobWithStatusChecksProperties(job, new GitHubStatusChecksProperties(scmFacade),
-                true, "GitHub SCM Source", true, true, true);
+                true, "GitHub SCM Source", true, true, true, "test-role", true);
     }
 
     @Test
@@ -50,9 +52,11 @@ class GitHubStatusChecksPropertiesTest {
         extension.setSkip(true);
         extension.setUnstableBuildNeutral(true);
         extension.setSuppressLogs(true);
+        extension.setRerunActionRole("test-role");
+        extension.setDisableRerunAction(true);
 
         assertJobWithStatusChecksProperties(job, new GitHubStatusChecksProperties(scmFacade),
-                true, "Git SCM", true, true, true);
+                true, "Git SCM", true, true, true, "test-role", true);
     }
 
     @Test
@@ -64,7 +68,7 @@ class GitHubStatusChecksPropertiesTest {
         when(scmFacade.findGitHubSCMSource(job)).thenReturn(Optional.of(source));
 
         assertJobWithStatusChecksProperties(job, new GitHubStatusChecksProperties(scmFacade),
-                true, "Jenkins", false, false, false);
+                true, "Jenkins", false, false, false, "", false);
     }
 
     @Test
@@ -78,7 +82,7 @@ class GitHubStatusChecksPropertiesTest {
         when(scm.getExtensions()).thenReturn(extensionList);
 
         assertJobWithStatusChecksProperties(job, new GitHubStatusChecksProperties(scmFacade),
-                true, "Jenkins", false, false, false);
+                true, "Jenkins", false, false, false, "", false);
     }
 
     @Test
@@ -89,18 +93,21 @@ class GitHubStatusChecksPropertiesTest {
         when(scmFacade.findGitSCM(job)).thenReturn(Optional.empty());
         when(scmFacade.findGitHubSCMSource(job)).thenReturn(Optional.empty());
         assertJobWithStatusChecksProperties(job, new GitHubStatusChecksProperties(scmFacade),
-                false, "Jenkins", false, false, false);
+                false, "Jenkins", false, false, false, "", false);
     }
 
     private static void assertJobWithStatusChecksProperties(final Job job, final GitHubStatusChecksProperties properties,
                                                             final boolean isApplicable, final String name,
                                                             final boolean isSkip, final boolean isUnstableBuildNeutral,
-                                                            final boolean isSuppressLogs) {
+                                                            final boolean isSuppressLogs, final String rerunActionRole,
+                                                            final boolean isDisableRerunAction) {
         assertThat(properties.isApplicable(job)).isEqualTo(isApplicable);
         assertThat(properties.getName(job)).isEqualTo(name);
         assertThat(properties.isSkipped(job)).isEqualTo(isSkip);
         assertThat(properties.isUnstableBuildNeutral(job)).isEqualTo(isUnstableBuildNeutral);
         assertThat(properties.isSuppressLogs(job)).isEqualTo(isSuppressLogs);
+        assertThat(properties.getRerunActionRole(job)).isEqualTo(rerunActionRole);
+        assertThat(properties.isDisableRerunAction(job)).isEqualTo(isDisableRerunAction);
     }
 }
 


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
This pull request will extend the functionality of the rerun action event with the following
 - a toggle which will allow the action to be disabled
 - a field which can be used to configure a role which users are required to have to be able to trigger the action

### Testing done
Changes are covered by automated tests

Frontend before the changes

<img width="1145" alt="image" src="https://github.com/user-attachments/assets/24845480-0c80-448e-9628-c6e7bf05a426" />

Frontend after the changes

<img width="1148" alt="image" src="https://github.com/user-attachments/assets/ad96af90-ab27-40a2-b8b5-a291e917fdc3" />

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
